### PR TITLE
Add tiingo python module

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [bronto-python](https://github.com/Scotts-Marketplace/bronto-python/) - Bronto API Integration for Python
 - [pytdx](https://github.com/rainx/pytdx) - Python Interface for retrieving chinese stock realtime quote data from TongDaXin Nodes
 - [pdblp](https://github.com/matthewgilbert/pdblp) - A simple interface to integrate pandas and the Bloomberg Open API
+- [tiingo](https://github.com/hydrosquall/tiingo-python) - Python interface for daily composite prices/OHLC/Volume + Real-time News Feeds, powered by the Tiingo Data Platform. 
 
 ### Excel Integration
 


### PR DESCRIPTION
Add link to a python library for working with the Tiingo API, (Docs are [here](https://api.tiingo.com/) )

cc @Yoshi9143