### PR TITLE
Included investpy among Python data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [metatrader5](https://pypi.org/project/MetaTrader5/) - API Connector to MetaTrader 5 Terminal
 - [akshare](https://github.com/jindaxiang/akshare) - AkShare is an elegant and simple financial data interface library for Python, built for human beings! <https://akshare.readthedocs.io>
 - [yahooquery](https://github.com/dpguthrie/yahooquery) - Python interface for retrieving data through unofficial Yahoo Finance API.
+- [investpy](https://github.com/alvarobartt/investpy) - Financial Data Extraction from Investing.com with Python! <https://investpy.readthedocs.io/>
 
 ### Excel Integration
 


### PR DESCRIPTION
[investpy](https://github.com/alvarobartt/investpy) has been included in the __Python__ section of __Data Sources__, since it is the only Python package available to retrieve data from Investing.com and it is currently used by a lot of users, so it may be useful to include it among the Financial Data Sources.

This repository was found from this reddit post: https://www.reddit.com/r/algotrading/comments/gy8t55/found_this_online_a_list_of_awesome_libraries_and/?ref=share&ref_source=link

investpy was mentioned in the same sub-reddit in this post: https://www.reddit.com/r/algotrading/comments/gda0iu/python_library_to_scrape_data_from_investingcom/