### PR TITLE
Add market-prices to Python section

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [pystlouisfed](https://github.com/TomasKoutek/pystlouisfed) - Python client for Federal Reserve Bank of St. Louis API - FRED, ALFRED, GeoFRED and FRASER.
 - [python-bcb](https://github.com/wilsonfreitas/python-bcb) - Python interface to Brazilian Central Bank web services.
 
+### Data Processing
+
+- [market-prices](https://github.com/maread99/market_prices) - Create meaningful OHLCV datasets from knowledge of [exchange-calendars](https://github.com/gerrymanoim/exchange_calendars) (works out-the-box with data from Yahoo Finance).
+
 ### Excel Integration
 
 - [xlwings](https://www.xlwings.org/) - Make Excel fly with Python.


### PR DESCRIPTION
Adds [market-prices](https://github.com/maread99/market_prices) to Python section.

Proposes a new 'Data Processing' subsection which would best reflect the package's purpose.

Thanks!