### PR TITLE
add crypto market data

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [pystlouisfed](https://github.com/TomasKoutek/pystlouisfed) - Python client for Federal Reserve Bank of St. Louis API - FRED, ALFRED, GeoFRED and FRASER.
 - [python-bcb](https://github.com/wilsonfreitas/python-bcb) - Python interface to Brazilian Central Bank web services.
 - [market-prices](https://github.com/maread99/market_prices) - Create meaningful OHLCV datasets from knowledge of [exchange-calendars](https://github.com/gerrymanoim/exchange_calendars) (works out-the-box with data from Yahoo Finance).
+- [tardis-python](https://github.com/tardis-dev/tardis-python) - Python interface for Tardis.dev high frequency crypto market data
+- [lake-api](https://github.com/crypto-lake/lakeapi) - Python interface for Crypto Lake high frequency crypto market data
 
 ### Excel Integration
 


### PR DESCRIPTION
add https://tardis.dev/ and https://crypto-lake.com/ market data providers