### PR TITLE
Add TradingStrategy.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [fastquant](https://github.com/enzoampil/fastquant) - fastquant allows you to easily backtest investment strategies with as few as 3 lines of python code.
 - [nautilus_trader](https://github.com/nautechsystems/nautilus_trader) - A high-performance algorithmic trading platform and event-driven backtester.
 - [YABTE](https://github.com/bsdz/yabte) - Yet Another (Python) BackTesting Engine.
+- [Trading Strategy](https://github.com/tradingstrategy-ai/getting-started) - TradingStrategy.ai is a market data, backtesting, live trading and investor management framework for decentralised finance
 
 ### Risk Analysis
 
@@ -257,6 +258,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [cif](https://github.com/LenkaV/CIF) - Python package that include few composite indicators, which summarize multidimensional relationships between individual economic indicators.
 - [finagg](https://github.com/theOGognf/finagg) - finagg is a Python package that provides implementations of popular and free financial APIs, tools for aggregating historical data from those APIs into SQL databases, and tools for transforming aggregated data into features useful for analysis and AI/ML.
 - [FinanceDatabase](https://github.com/JerBouma/FinanceDatabase) - This is a database of 300.000+ symbols containing Equities, ETFs, Funds, Indices, Currencies, Cryptocurrencies and Money Markets.
+- [Trading Strategy](https://github.com/tradingstrategy-ai/trading-strategy/) - download price data for decentralised exchanges and lending protocols (DeFi)
 
 ### Excel Integration
 


### PR DESCRIPTION
- Adding TradingStrategy.ai in the framework and data sources sections
- Note: Links point to different repos
- Disclaimer: I am the author