### PR TITLE
fix #212

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 ### Data Sources
 
 - [yfinance](https://github.com/ranaroussi/yfinance) - Yahoo! Finance market data downloader (+faster Pandas Datareader)
+- [defeatbeta-api](https://github.com/defeat-beta/defeatbeta-api) - An open-source alternative to Yahoo Finance's market data APIs with higher reliability.
 - [findatapy](https://github.com/cuemacro/findatapy) - Python library to download market data via Bloomberg, Quandl, Yahoo etc.
 - [googlefinance](https://github.com/hongtaocai/googlefinance) - Python module to get real-time stock data from Google Finance API.
 - [yahoo-finance](https://github.com/lukaszbanasiak/yahoo-finance) - Python module to get stock data from Yahoo! Finance.


### PR DESCRIPTION
Add Python - Data Sources

https://github.com/defeat-beta/defeatbeta-api

An open-source alternative to Yahoo Finance's market data APIs with higher reliability.

Key features:
✅ Reliable Data：Sources market data directly from Hugging Face's [yahoo-finance-data](https://huggingface.co/datasets/bwzheng2010/yahoo-finance-data) dataset, bypassing Yahoo scraping.

✅ No Rate Limits：Hugging Face's infrastructure provides guaranteed access without API throttling or quotas.

✅ High Performance：[DuckDB's OLAP engine](https://duckdb.org/) + [cache_httpfs](https://duckdb.org/community_extensions/extensions/cache_httpfs.html) extension delivers sub-second query latency.

✅ SQL-Compatible：Python-native interface with full SQL support via DuckDB's optimized execution.