### PR TITLE
Add fedfred and edgar-sec  to data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Financial Data](https://financialdata.net/) - Stock Market and Financial Data API.
 - [SaxoOpenAPI](https://www.developer.saxo/) - Saxo Bank financial data API.
 - [fedfred](https://nikhilxsunder.github.io/fedfred/) - FRED & GeoFRED Economic data API with preprocessed dataframe output in pandas/geopandas, polars/polars_st, and dask dataframes/geodataframes.
+- [edgar-sec](https://nikhilxsunder.github.io/edgar-sec/) - EDGAR Financial data API with preprocessed dataclass outputs.
 
 ### Excel Integration
 


### PR DESCRIPTION
Add fedfred for FRED and GeoFRED Economic data with pre-parsed dataframe/geodataframe and python dataclass outputs

Docs: https://nikhilxsunder.github.io/fedfred/
Github: https://github.com/nikhilxsunder/fedfred
Conda-Forge: https://anaconda.org/conda-forge/fedfred
PyPI: https://pypi.org/project/fedfred/

Add edgar-sec for EDGAR Financial datawith pre-parsed dataclass outputs

Docs: https://nikhilxsunder.github.io/edgar-sec/
Github: https://github.com/nikhilxsunder/edgar-sec
Conda-Forge: https://anaconda.org/conda-forge/edgar-sec
PyPI: https://pypi.org/project/edgar-sec/