### PR TITLE
Add RunMat to Rust section

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,8 @@ date conversion, scaling factor values, and filtering by the specified date.
 - [SlidingFeatures](https://github.com/MathisWellmann/sliding_features-rs) - Chainable tree-like sliding windows for signal processing and technical analysis.
 - [RustQuant](https://github.com/avhz/RustQuant) - Quantitative finance library written in Rust.
 - [finalytics](https://github.com/Nnamdi-sys/finalytics) - A rust library for financial data analysis.
+- [RunMat](https://github.com/runmat-org/runmat) - Rust runtime for MATLAB-syntax array math with automatic CPU/GPU execution and fused kernels for quant simulations.
+
 
 
 ## Reproducing Works, Training & Books


### PR DESCRIPTION
RunMat is an open-source Rust runtime for MATLAB-syntax array math. It automatically chooses CPU or GPU and fuses long math chains into fast kernels. Quants can use it for workloads like Monte Carlo risk, covariance, and large matrix math, with good speedups vs NumPy and PyTorch on our benchmarks.

This PR adds RunMat to the Rust section.

Repo: https://github.com/runmat-org/runmat