### PR TITLE
Add OilPriceAPI to Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [bbgbridge](https://github.com/ran404/bbgbridge) - Easy to use Bloomberg Desktop API wrapper for Python.
 - [polygon.io](https://github.com/polygon-io/client-python) - A python library for Polygon.io financial data APIs.
 - [alpha_vantage](https://github.com/RomelTorres/alpha_vantage) - A python wrapper for Alpha Vantage API for financial data.
+- [oilpriceapi](https://github.com/OilpriceAPI/python-sdk) - Python SDK for real-time oil and commodity prices (WTI, Brent, Urals, natural gas, coal) with OpenBB integration.
 - [FinanceDataReader](https://github.com/FinanceData/FinanceDataReader) - Open Source Financial data reader for U.S, Korean, Japanese, Chinese, Vietnamese Stocks
 - [pystlouisfed](https://github.com/TomasKoutek/pystlouisfed) - Python client for Federal Reserve Bank of St. Louis API - FRED, ALFRED, GeoFRED and FRASER.
 - [python-bcb](https://github.com/wilsonfreitas/python-bcb) - Python interface to Brazilian Central Bank web services.


### PR DESCRIPTION
## Summary

Adding [OilPriceAPI](https://oilpriceapi.com) to the Data Sources section.

## What is OilPriceAPI?

OilPriceAPI provides real-time and historical oil and commodity prices via a REST API:

- **Crude Oil**: WTI, Brent, Urals (Russian export blend), Dubai
- **Natural Gas**: US Henry Hub, EU TTF, UK NBP
- **Coal**: Thermal coal prices
- **Diesel/Gasoline**: US national averages

## Why Add It?

- Fills a gap for commodity/energy price data in the quant ecosystem
- Python SDK available on PyPI: `pip install oilpriceapi`
- Node.js SDK also available: `npm install oilpriceapi`
- Working on OpenBB provider integration

## Links

- Website: https://oilpriceapi.com
- Python SDK: https://github.com/OilpriceAPI/python-sdk
- Documentation: https://docs.oilpriceapi.com