### PR TITLE
Add Vedika Astrology Finance API Python SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [market-prices](https://github.com/maread99/market_prices) - Create meaningful OHLCV datasets from knowledge of [exchange-calendars](https://github.com/gerrymanoim/exchange_calendars) (works out-the-box with data from Yahoo Finance).
 - [tardis-python](https://github.com/tardis-dev/tardis-python) - Python interface for Tardis.dev high frequency crypto market data
 - [lake-api](https://github.com/crypto-lake/lake-api) - Python interface for Crypto Lake high frequency crypto market data
+- [vedika-sdk-python](https://github.com/vedika-ai/vedika-sdk-python) - Python SDK for Vedika Astrology Finance API, providing AI-powered Vedic astrology calculations for financial markets (muhurta timing, planetary transits, dasha periods, and market sentiment analysis)
 - [tessa](https://github.com/ymyke/tessa) - simple, hassle-free access to price information of financial assets (currently based on yfinance and pycoingecko), including search and a symbol class.
 - [pandaSDMX](https://github.com/dr-leo/pandaSDMX) - Python package that implements SDMX 2.1 (ISO 17369:2013), a format for exchange of statistical data and metadata used by national statistical agencies, central banks, and international organisations.
 - [cif](https://github.com/LenkaV/CIF) - Python package that include few composite indicators, which summarize multidimensional relationships between individual economic indicators.


### PR DESCRIPTION
## Description

Adding Vedika Astrology Finance API Python SDK to the Data Sources section.

Vedika API is a financial astrology API that provides:
- AI-powered Vedic astrology calculations for financial markets
- Muhurta timing (auspicious timing for trades)
- Planetary transits analysis
- Dasha period calculations
- Market sentiment analysis based on astrological indicators

**Link:** https://vedika.io  
**Python SDK:** https://github.com/vedika-ai/vedika-sdk-python

This is relevant for quantitative finance practitioners who incorporate alternative data sources and astrological analysis in their trading strategies.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update (adding new resource to awesome list)