### PR TITLE
Add Japan finance data libraries (edinet-mcp, estat-mcp, tdnet-disclosure-mcp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [jsm](https://pypi.org/project/jsm/) - Get the japanese stock market data.
 - [edinet-mcp](https://github.com/ajtgjmdjp/edinet-mcp) - Parse Japanese XBRL financial statements from EDINET with 161 normalized labels, 26 financial metrics, and multi-company screening.
 - [estat-mcp](https://github.com/ajtgjmdjp/estat-mcp) - Access Japanese government statistics (e-Stat) covering population, GDP, CPI, labor, and trade data with MCP integration and Polars export.
-- [boj-mcp](https://github.com/ajtgjmdjp/boj-mcp) - Access Bank of Japan statistics (CGPI, TANKAN, Flow of Funds, Balance of Payments) from official flat files. No API key required.
+- [tdnet-disclosure-mcp](https://github.com/ajtgjmdjp/tdnet-disclosure-mcp) - Access Japanese timely disclosures (TDNet) via MCP. Retrieve earnings, dividends, forecasts, buybacks, and other filings for 4,000+ listed companies. No API key required.
 - [cn_stock_src](https://github.com/jealous/cn_stock_src) - Utility for retrieving basic China stock data from different sources.
 - [coinmarketcap](https://github.com/barnumbirr/coinmarketcap) - Python API for coinmarketcap.
 - [after-hours](https://github.com/datawrestler/after-hours) - Obtain pre market and after hours stock prices for a given symbol.


### PR DESCRIPTION
Adds three Python libraries for Japanese financial data to the **Data Sources** section (after `jsm`):

| Library | Description |
|---|---|
| [edinet-mcp](https://github.com/ajtgjmdjp/edinet-mcp) | EDINET XBRL financial statements — BS/PL/CF across J-GAAP/IFRS/US-GAAP |
| [estat-mcp](https://github.com/ajtgjmdjp/estat-mcp) | e-Stat government statistics — 3,000+ tables (GDP, CPI, population, etc.) |
| [tdnet-disclosure-mcp](https://github.com/ajtgjmdjp/tdnet-disclosure-mcp) | TDNet timely disclosures — earnings, dividends, forecasts, buybacks for 4,000+ companies |

All three are Apache-2.0 licensed, published on PyPI, and placed after `jsm` (existing Japanese data library) in the list.