### PR TITLE
Add estat-mcp to Python Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [ccy](https://github.com/lsbardel/ccy) - Python module for currencies.
 - [tushare](https://pypi.org/project/tushare/) - A utility for crawling historical and Real-time Quotes data of China stocks.
 - [jsm](https://pypi.org/project/jsm/) - Get the japanese stock market data.
+- [estat-mcp](https://github.com/ajtgjmdjp/estat-mcp) - Access Japanese government statistics (e-Stat) covering population, GDP, CPI, labor, and trade data with MCP integration and Polars export.
 - [cn_stock_src](https://github.com/jealous/cn_stock_src) - Utility for retrieving basic China stock data from different sources.
 - [coinmarketcap](https://github.com/barnumbirr/coinmarketcap) - Python API for coinmarketcap.
 - [after-hours](https://github.com/datawrestler/after-hours) - Obtain pre market and after hours stock prices for a given symbol.


### PR DESCRIPTION
## Summary

Add [estat-mcp](https://github.com/ajtgjmdjp/estat-mcp) to the Python > Data Sources section, placed next to `jsm` (another Japanese data tool).

estat-mcp provides access to Japan's [e-Stat](https://www.e-stat.go.jp/) (政府統計の総合窓口), the official portal for Japanese government statistics. It covers 3,000+ statistical tables including population, GDP, CPI, labor, and trade data.

**Key features:**
- Search, retrieve metadata, and fetch data with automatic pagination
- Polars DataFrame export for analysis
- MCP (Model Context Protocol) integration for AI agents
- Published on [PyPI](https://pypi.org/project/estat-mcp/)

**Related:** Sister project of [edinet-mcp](https://github.com/ajtgjmdjp/edinet-mcp) (PR #249) — together they cover company financials (EDINET) + macroeconomic statistics (e-Stat) for Japanese data.