### PR TITLE
Add boj-mcp to Python Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [ccy](https://github.com/lsbardel/ccy) - Python module for currencies.
 - [tushare](https://pypi.org/project/tushare/) - A utility for crawling historical and Real-time Quotes data of China stocks.
 - [jsm](https://pypi.org/project/jsm/) - Get the japanese stock market data.
+- [boj-mcp](https://github.com/ajtgjmdjp/boj-mcp) - Access Bank of Japan statistics (CGPI, TANKAN, Flow of Funds, Balance of Payments) from official flat files with MCP integration. No API key required.
 - [cn_stock_src](https://github.com/jealous/cn_stock_src) - Utility for retrieving basic China stock data from different sources.
 - [coinmarketcap](https://github.com/barnumbirr/coinmarketcap) - Python API for coinmarketcap.
 - [after-hours](https://github.com/datawrestler/after-hours) - Obtain pre market and after hours stock prices for a given symbol.


### PR DESCRIPTION
## Summary

Add [boj-mcp](https://github.com/ajtgjmdjp/boj-mcp) to the Python > Data Sources section, placed next to `jsm` (another Japanese data tool).

boj-mcp provides access to Bank of Japan statistical flat files — covering CGPI (Corporate Goods Price Index), TANKAN survey, Flow of Funds, Balance of Payments, and BIS statistics. No API key required.

**Key features:**
- Download and analyze 16 BOJ flat file datasets
- Automatic Shift_JIS encoding handling
- Polars DataFrame export for analysis
- MCP (Model Context Protocol) integration for AI agents
- Published on [PyPI](https://pypi.org/project/boj-mcp/)

**Related:** Sister project of [edinet-mcp](https://github.com/ajtgjmdjp/edinet-mcp) (PR #249) and [estat-mcp](https://github.com/ajtgjmdjp/estat-mcp) — together they cover Japanese financial data from three official sources.