### PR TITLE
Add 13F Insight to Python Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [FinanceDatabase](https://github.com/JerBouma/FinanceDatabase) - This is a database of 300.000+ symbols containing Equities, ETFs, Funds, Indices, Currencies, Cryptocurrencies and Money Markets.
 - [Trading Strategy](https://github.com/tradingstrategy-ai/trading-strategy/) - download price data for decentralised exchanges and lending protocols (DeFi)
 - [datamule-python](https://github.com/john-friedman/datamule-python) - A package to work with SEC data. Incorporates datamule endpoints.
+- [13F Insight](https://13finsight.com/) - Track institutional investor 13F holdings with AI-powered analysis, position change alerts, and filing summaries.
 - [Earnings Feed](https://earningsfeed.com/api) - Real-time SEC filings, insider trades, and institutional holdings API.
 - [Financial Data](https://financialdata.net/) - Stock Market and Financial Data API.
 - [SaxoOpenAPI](https://www.developer.saxo/) - Saxo Bank financial data API.


### PR DESCRIPTION
## What is 13F Insight?

[13F Insight](https://13finsight.com) is a platform for tracking SEC 13F filings from 10,000+ institutional investors with AI-powered analysis.

### Key Features
- **13F Holdings Tracking** — Monitor portfolio changes across 10,000+ institutional investors managing over $100M
- **AI-Powered Analysis** — Automated insights on institutional buying/selling patterns
- **Insider Trading (Form 4)** — Combined 13F + insider trading data in one place
- **Activist Investor Monitoring** — 13D/G filings for activist positions
- **Real-time Filing Alerts** — Get notified when new filings are published

### Why it belongs here
13F Insight fits alongside other SEC data sources in the Data Sources section (near `datamule-python`, `Earnings Feed`, `edgar-sec`) as a specialized tool for institutional holdings analysis.

### Placement
Added to the **Python > Data Sources** section, grouped with other SEC filing and institutional data tools.