### PR TITLE
Add Stock Sentiment API to Sentiment Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 
 ### Sentiment Analysis
 - [Asset News Sentiment Analyzer](https://github.com/KVignesh122/AssetNewsSentimentAnalyzer) - Sentiment analysis and report generation package for financial assets and securities utilizing GPT models.
+- [Social Stock Sentiment API](https://api.adanos.org/docs) - REST API analyzing Reddit and X/Twitter for stock mentions and sentiment, providing buzz scores, trending stocks, and AI-generated trend explanations.
 
 ### Quant Research Environment
 


### PR DESCRIPTION
## Summary

Adds [Stock Sentiment API](https://api.adanos.org/docs) to the **Sentiment Analysis** section under Python.

**What it does:**
- REST API analyzing Reddit and X/Twitter for stock mentions and sentiment
- Provides buzz scores (0-100), trending stocks, and AI-generated trend explanations
- VADER + RoBERTa ONNX ensemble for financial sentiment analysis
- Free tier with self-service API keys

**Why it fits:**
- The Sentiment Analysis section currently has only 1 entry
- This fills a gap for real-time social media sentiment data — no similar tool listed
- Production API with OpenAPI 3.1 docs at [api.adanos.org/docs](https://api.adanos.org/docs)