### PR TITLE
Add goMacro.ai to Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [pandas_market_calendars](https://github.com/rsheftel/pandas_market_calendars) - Exchange calendars to use with pandas for trading applications.
 
 ### Data Sources
+- [goMacro.ai](https://gomacro.ai) - AI-powered economic calendar with institutional-grade insights, bull/bear/base case scenario planning for NFP, CPI, PPI and other macro data releases.
 - [StockAPI](https://stockapi.com.cn) – Free real-time Chinese stock data (REST & WebSocket).
 - [yfinance](https://github.com/ranaroussi/yfinance) - Yahoo! Finance market data downloader (+faster Pandas Datareader)
 - [defeatbeta-api](https://github.com/defeat-beta/defeatbeta-api) - An open-source alternative to Yahoo Finance's market data APIs with higher reliability.


### PR DESCRIPTION
## What is goMacro.ai?

[goMacro.ai](https://gomacro.ai) is an AI-powered economic calendar that provides institutional-grade insights for economic data releases (NFP, CPI, PPI, Jobless Claims, etc.). It offers:

- **Institutional-grade summaries** on the effects of various data prints
- **Bull/Bear/Base case scenario planning** for when data drops
- **Portfolio impact analysis** so traders know what each release means for their positions

## Why add it?

It fits well in the **Data Sources** section as a tool that enhances economic calendar data with AI-driven analysis — useful for quant traders who trade macro events.

Free to use with a freemium model.