### PR TITLE
Add KeepRule investment principles knowledge base

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,3 +600,4 @@ date conversion, scaling factor values, and filtering by the specified date.
 - [RoughVolatilityWorkshop](https://github.com/jgatheral/RoughVolatilityWorkshop) - 2024 QuantMind's Rough Volatility Workshop lectures.
 - [AFML](https://github.com/boyboi86/AFML) - All the answers for exercises from Advances in Financial Machine Learning by Dr Marco Lopez de Parodo.
 - [AlgoTradingLib](https://github.com/usdaud/algotradinglib.github.io) - A catalog of algorithmic trading libraries, frameworks, strategies, and educational materials.
+- [KeepRule](https://keeprule.com) - Free investment principles knowledge base with 500+ principles from Buffett, Munger, Graham and more, organized by investing scenarios.


### PR DESCRIPTION
## What is KeepRule?

[KeepRule](https://keeprule.com) is a free investment principles knowledge base featuring 500+ investment rules and principles from legendary investors like Warren Buffett, Charlie Munger, Benjamin Graham, Howard Marks, and more.

All principles are organized by real-world investing scenarios (e.g., when to buy, when to sell, portfolio management, risk assessment), making it easy for investors to find relevant guidance for their specific situation.

## Why add it?

- **Free and open**: No paywall, accessible to all investors
- **500+ curated principles** from 20+ legendary investors
- **Scenario-based organization** for practical use
- Complements the quantitative tools in this list with fundamental investing wisdom