### PR TITLE
Add Congressional Stock Brain to Commercial & Proprietary Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Telonex](https://telonex.io) - Tick-level prediction market data (trades, quotes, orderbooks, on-chain fills) via REST API and Python SDK.
 - [ValueRay](https://www.valueray.com/api) - Technical, quantitative and sentiment data for stocks and ETFs with risk metrics, peer percentiles and market regime signals. Optimized for AI/LLM agents.
 - [VertData](https://vertdata.com) - Institutional-grade financial intelligence platform. Track 43K+ congressional trades (STOCK Act), SEC insider Form 4 filings, 25 superinvestor 13F portfolios, CFTC futures positioning, ARK ETF holdings, and short interest — all scored by AI for signal strength.
+- - [Congressional Stock Brain](https://congressionalstockbrain.com) - Free AI-powered fintech tool that ingests U.S. STOCK Act disclosures and scores each congressional trade for signal strength. Filter by lawmaker, stock, or sector. Includes a natural language query console ("Ask the Brain") powered by AI. Free tier available.
 - [KeepRule](https://keeprule.com/) - Curated library of decision-making principles and investment wisdom from masters like Buffett and Munger, featuring mental models for better investment thinking.
 - [ML-Quant](https://www.ml-quant.com/) - Top Quant resources like ArXiv (sanity), SSRN, RePec, Journals, Podcasts, Videos, and Blogs.
 

--- a/README.md
+++ b/README.md
@@ -583,7 +583,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Telonex](https://telonex.io) - Tick-level prediction market data (trades, quotes, orderbooks, on-chain fills) via REST API and Python SDK.
 - [ValueRay](https://www.valueray.com/api) - Technical, quantitative and sentiment data for stocks and ETFs with risk metrics, peer percentiles and market regime signals. Optimized for AI/LLM agents.
 - [VertData](https://vertdata.com) - Institutional-grade financial intelligence platform. Track 43K+ congressional trades (STOCK Act), SEC insider Form 4 filings, 25 superinvestor 13F portfolios, CFTC futures positioning, ARK ETF holdings, and short interest — all scored by AI for signal strength.
-- - [Congressional Stock Brain](https://congressionalstockbrain.com) - Free AI-powered fintech tool that ingests U.S. STOCK Act disclosures and scores each congressional trade for signal strength. Filter by lawmaker, stock, or sector. Includes a natural language query console ("Ask the Brain") powered by AI. Free tier available.
+- [Congressional Stock Brain](https://congressionalstockbrain.com) - `Web` - Free AI-powered tool for scoring U.S. STOCK Act congressional trade disclosures by significance, filterable by lawmaker, ticker, and sector. No public GitHub repo.
 - [KeepRule](https://keeprule.com/) - Curated library of decision-making principles and investment wisdom from masters like Buffett and Munger, featuring mental models for better investment thinking.
 - [ML-Quant](https://www.ml-quant.com/) - Top Quant resources like ArXiv (sanity), SSRN, RePec, Journals, Podcasts, Videos, and Blogs.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Financial Instruments & Pricing](#financial-instruments-pricing)
 - [Technical Indicators](#technical-indicators)
 - [Trading & Backtesting](#trading-backtesting)
-- [Portfolio Optimization & Risk Analysis](#portfolio-optimization-risk-analysis)
+- [Portfolio Optimization & Risk Analysis](#portfolio-optimization-risk-analysihs)
 - [Factor Analysis](#factor-analysis)
 - [Sentiment Analysis & Alternative Data](#sentiment-analysis-alternative-data)
 - [Time Series Analysis](#time-series-analysis)
@@ -583,7 +583,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Telonex](https://telonex.io) - Tick-level prediction market data (trades, quotes, orderbooks, on-chain fills) via REST API and Python SDK.
 - [ValueRay](https://www.valueray.com/api) - Technical, quantitative and sentiment data for stocks and ETFs with risk metrics, peer percentiles and market regime signals. Optimized for AI/LLM agents.
 - [VertData](https://vertdata.com) - Institutional-grade financial intelligence platform. Track 43K+ congressional trades (STOCK Act), SEC insider Form 4 filings, 25 superinvestor 13F portfolios, CFTC futures positioning, ARK ETF holdings, and short interest — all scored by AI for signal strength.
-- [Congressional Stock Brain](https://congressionalstockbrain.com) - `Web` - Free AI-powered tool for scoring U.S. STOCK Act congressional trade disclosures by significance, filterable by lawmaker, ticker, and sector. No public GitHub repo.
+- [Congressional Stock Brain](https://congressionalstockbrain.com) - `Data` - Free AI-powered tool for scoring U.S. STOCK Act congressional trade disclosures by significance, filterable by lawmaker, ticker, and sector. No public GitHub repo.
 - [KeepRule](https://keeprule.com/) - Curated library of decision-making principles and investment wisdom from masters like Buffett and Munger, featuring mental models for better investment thinking.
 - [ML-Quant](https://www.ml-quant.com/) - Top Quant resources like ArXiv (sanity), SSRN, RePec, Journals, Podcasts, Videos, and Blogs.
 


### PR DESCRIPTION
Adding Congressional Stock Brain to the Commercial & Proprietary Services section.

Congressional Stock Brain (congressionalstockbrain.com) is a free AI-powered fintech tool specifically focused on U.S. congressional STOCK Act disclosures. It ingests all House and Senate filings and scores each trade for signal strength using AI.

Unlike VertData (which is institutional-grade and covers 13F, CFTC, etc.), CSB is:
- Specifically focused on congressional STOCK Act disclosures only
- Free tier available (core features free)
- Designed for retail investors, not institutions
- Includes a natural language query console ("Ask the Brain") powered by Claude AI

Format follows CONTRIBUTING.md guidelines. Placed after VertData in alphabetical order within the section.