### PR TITLE
Add Apex Quant (Parliament) - adversarial multi-agent LLM framework for US equity decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [OpenFinClaw](https://github.com/cryptoSUN2049/openFinclaw) - `Python` `Rust` - AI-native one-person hedge fund platform with Rust trading engine. Natural language → strategy → backtest → execution in 60s. Multi-market (US/HK/CN/Crypto), self-evolving strategy pipeline. Built on OpenClaw (68K+ stars).
 
 - [TradeClaw](https://github.com/naimkatiman/tradeclaw) - `Node.js` `TypeScript` - Open-source self-hosted AI trading signal platform. Generates buy/sell signals using RSI, MACD, EMA, Bollinger Bands for forex, crypto and commodities. Deployable via Docker Compose. ([Demo](https://tradeclaw.win/dashboard))
+- [Apex Quant (Parliament)](https://github.com/sst19910323/apex_parliament) - Adversarial multi-agent LLM framework for US equity decision-making, using constitutional debate between a mandated bull, a risk-focused realist, and an arbitrator to suppress overconfidence.
+- 
 ## Portfolio Optimization & Risk Analysis
 
 - [skfolio](https://github.com/skfolio/skfolio) - `Python` - Python library for portfolio optimization built on top of scikit-learn. It provides a unified interface and sklearn compatible tools to build, tune and cross-validate portfolio models.


### PR DESCRIPTION
Adding Apex Quant (Parliament), an open-source adversarial debate framework for US equity decision-making. Three LLM agents with fixed opposing mandates debate each decision, with an arbitrator prevented from resolving until contradictions are fully surfaced. Paper on SSRN: https://papers.ssrn.com/abstract=6354961