### PR TITLE
Add Stock Research Desk to AI finance tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [pinkfish](https://github.com/fja05680/pinkfish) - `Python` - A backtester and spreadsheet library for security analysis.
 - [PRISM-INSIGHT](https://github.com/dragon1086/prism-insight) - `Python` - AI-powered stock analysis system with 13 specialized agents, automated trading via KIS API, supporting Korean & US markets.
 - [FinClaw](https://github.com/NeuZhou/finclaw) - `Python` - AI-powered financial intelligence engine with 8 master strategies across US, CN, and HK markets. Multi-agent architecture with +29.1% annual alpha. 227 tests.
+- [Stock Research Desk](https://github.com/wd041216-bit/stock-research-desk) - `Python` - Cloud-only multi-agent equity research desk for single-name deep dives, sector screening, watchlists, scenario analysis, and bilingual document delivery.
 - [aat](https://github.com/timkpaine/aat) - `Python` - Async Algorithmic Trading Engine.
 - [Backtesting.py](https://kernc.github.io/backtesting.py/) - `Python` - Backtest trading strategies in Python.
 - [catalyst](https://github.com/enigmampc/catalyst) - `Python` - An Algorithmic Trading Library for Crypto-Assets in Python.


### PR DESCRIPTION
Adds [Stock Research Desk](https://github.com/wd041216-bit/stock-research-desk), a cloud-only multi-agent equity research desk for ticker memos, theme screening, watchlists, and one-DOCX delivery.

Why it fits:
- single-name deep-dive stock research
- theme / sector screening before expensive finalist research
- evidence quality filtering, red-team dissent, scenario branches, and target prices with time horizons
- mailbox-friendly watchlist refreshes and a Codex skill mode
- final human-facing output is one desktop DOCX, while JSON / memory state stays internal

Latest public references:
- [Project Showcase](https://github.com/wd041216-bit/stock-research-desk/blob/main/docs/showcase.md)
- [Sample Research Memo](https://github.com/wd041216-bit/stock-research-desk/blob/main/docs/sample-memo.md)
- [Sample Screening Summary](https://github.com/wd041216-bit/stock-research-desk/blob/main/docs/sample-screening.md)
- [CLI Workflow](https://github.com/wd041216-bit/stock-research-desk/blob/main/docs/cli-workflow.md)
