### PR TITLE
Add Lumibot to Trading & Backtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Orallexa](https://github.com/alex-jb/orallexa-ai-trading-agent) - `Python` - AI trading operating system with 9 ML models (RF, XGBoost, EMAformer, MOIRAI-2, Chronos-2, DDPM, PPO RL, GNN, LR) ranked by Sharpe ratio, Claude AI synthesis with dual-tier routing (~$0.003/analysis), real-time Next.js dashboard, Alpaca paper trading, and 277 automated tests.
 - [the0](https://github.com/alexanderwanyoike/the0) - `Python` - Self-hosted execution engine for algorithmic trading bots. Write strategies in Python, TypeScript, Rust, C++, C#, Scala, or Haskell and deploy with one command. Each bot runs in an isolated container with scheduled or streaming execution.
 - [Investing algorithm framework](https://github.com/coding-kitties/investing-algorithm-framework) - `Python` - Framework for developing, backtesting, and deploying automated trading algorithms.
+- [Lumibot](https://github.com/Lumiwealth/lumibot) - `Python` - Algorithmic trading framework where the same code runs for backtesting and live trading across stocks, options, crypto, futures, and forex with multiple brokers including Alpaca, Interactive Brokers, Tradier, and Schwab.
 - [QSTrader](https://github.com/mhallsmoore/qstrader) - `Python` - QSTrader backtesting simulation engine.
 - [Blankly](https://github.com/Blankly-Finance/Blankly) - `Python` - Fully integrated backtesting, paper trading, and live deployment.
 - [zipline](https://github.com/quantopian/zipline) - `Python` - Pythonic algorithmic trading library.


### PR DESCRIPTION
## What is Lumibot?

[Lumibot](https://github.com/Lumiwealth/lumibot) is an open-source Python framework (MIT license) for algorithmic trading backtesting and live deployment.

## Why it belongs on this list

- **1,333+ GitHub stars** with active community
- **Actively maintained**: Latest release v4.4.60 (April 2026), consistent weekly commits
- **Multi-asset**: Stocks, options, crypto, futures, and forex
- **Multiple brokers**: Alpaca, Interactive Brokers, Tradier, Schwab, CCXT (100+ crypto exchanges)
- **Same code for backtesting and live trading** — write once, deploy anywhere
- **Built-in AI trading agent runtime** for LLM-powered strategies
- **Well-documented**: Comprehensive README with examples and full documentation site

## Checklist

- [x] Entry follows the required format: `- [Name](url) - \`Language\` - Description.`
- [x] Placed under the correct category: **Trading & Backtesting**
- [x] Project is active (commits within the last 12 months)
- [x] Project has a clear README with usage examples
- [x] Not a duplicate (searched existing list and previous PRs)
- [x] Single project per PR
- [x] Uses `https://` URL
- [x] Description ends with a period