### PR TITLE
Add prediction-market-maker to Prediction Markets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Polymarket Scanner API](https://github.com/vesper-astrena/polymarket-scanner-api) - `Python` - Real-time arbitrage detection API for Polymarket prediction markets, scanning 12,000+ markets for mispricings.
 - [SimpleFunctions](https://github.com/spfunctions/simplefunctions-cli) - `JavaScript` - Prediction market intelligence CLI for Kalshi and Polymarket. Causal thesis models, edge detection, 24/7 orderbook monitoring, what-if scenarios, and trade execution. MCP server for AI agent integration.
 - [pmxt](https://github.com/pmxt-dev/pmxt) - `Python` `JavaScript` - The CCXT for prediction markets. A unified API for trading on Polymarket, Kalshi, and more.
+- [prediction-market-maker](https://github.com/octavi42/prediction-market-maker) - `Python` - Open-source market-making strategy that placed #2 in Paradigm's prediction market challenge, with full strategy evolution and analysis.
 
 ## Calendars & Market Hours
 


### PR DESCRIPTION
Adds an open-source prediction market making strategy with:
- Full documented strategy (80 lines, MIT licensed)
- 7 milestone versions showing evolution from -$17 to +$47 mean edge
- Benchmark scripts and performance charts
- Detailed analysis of what failed and why

Placed #2 in Paradigm's Automated Research Hackathon (April 2026).