### PR TITLE
Add cipher-starter to Reproducing Works & Training section

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [systematictradingexamples](https://github.com/robcarver17/systematictradingexamples) - Examples of code related to book [Systematic Trading](www.systematictrading.org) and [blog](http://qoppac.blogspot.com).
 - [pysystemtrade_examples](https://github.com/robcarver17/pysystemtrade_examples) - Examples using pysystemtrade for Robert Carver's [blog](http://qoppac.blogspot.com).
 - [ML_Finance_Codes](https://github.com/mfrdixon/ML_Finance_Codes) - Machine Learning in Finance: From Theory to Practice Book.
+- [cipher-starter](https://github.com/cryptomotifs/cipher-starter) — Solo crypto quant starter kit: 12 playbooks covering trading strategy, risk rails, 3-tier wallet architecture, MEV mitigation, Canadian NI 31-103 compliance, Oracle Cloud Always Free infra, and a 7-day MVP calendar for a Solana signal engine + autonomous trading bot.
 - [Hands-On Machine Learning for Algorithmic Trading](https://github.com/packtpublishing/hands-on-machine-learning-for-algorithmic-trading) - Hands-On Machine Learning for Algorithmic Trading, published by Packt.
 - [financialnoob-misc](https://github.com/financialnoob/misc) - Codes from @financialnoob's posts.
 - [MesoSim Options Trading Strategy Library](https://github.com/deltaray-io/strategy-library) - Free and public Options Trading strategy library for MesoSim.


### PR DESCRIPTION
Adding a starter kit I published for solo devs building signal engines + autonomous trading bots.

**What it is**: 12 free markdown playbooks (~150 pages) covering the complete engineering + strategy + risk + security + compliance + infra decisions for a Solana-native quant system on a $0/mo infrastructure budget.

**Repo**: https://github.com/cryptomotifs/cipher-starter

**Why it fits here**: this section includes training materials, book companions, and research notebooks. The kit compresses ~4 months of solo research into decision-ready playbooks with code references and SQL schemas, in the same spirit as the systematictradingexamples / ML_Finance_Codes entries.

**Topics covered**:
- Trading playbook: universe selection, top-K signal filtering, eighth-Kelly sizing, 3-10 day hold with ATR stops
- Risk rails: 5 non-negotiable circuit breakers, 30-day paper-trade gate, kill switches
- Security: 3-tier wallet architecture, KMS envelope + isolated signer subprocess
- Architecture: 18 new Python modules mapped, 7-day MVP calendar, Rust-to-Python salvage list
- Canadian compliance memo: NI 31-103 exemption path, CCPC timing, SR&ED credit mechanics
- Oracle Cloud Always Free deploy with systemd, 99% SLO, 8 P0 alert runbooks
- 23 free-tier API integration workflows (Helius, Alchemy, Bitquery, etc.)

Happy to refine the description or move the entry to a different section if this isn't the best fit. Thanks for maintaining the list!