### PR TITLE
Add FractalCycles (cycle detection via Goertzel + Bartels + Hurst)

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [KeepRule](https://keeprule.com/) - Curated library of decision-making principles and investment wisdom from masters like Buffett and Munger, featuring mental models for better investment thinking.
 - [ML-Quant](https://www.ml-quant.com/) - Top Quant resources like ArXiv (sanity), SSRN, RePec, Journals, Podcasts, Videos, and Blogs.
 - [RealMarketAPI](https://realmarketapi.com/) - Provides ultra-low latency market data for gold, forex, crypto, and stocks via REST, WebSocket, and MCP—built for speed, reliability, and scale.
+- [FractalCycles](https://fractalcycles.com) - Cycle detection platform using Goertzel DFT for spectral analysis, Bartels test for statistical significance, and Hurst exponent (R/S) for regime classification across equities, FX, commodities, and crypto.
 
 ## Related Lists
 


### PR DESCRIPTION
Adds [FractalCycles](https://fractalcycles.com) to the Commercial & Proprietary Services section.

**What it is**
A hosted platform for detecting statistically validated cycles in market data. Pipeline:
1. Detrending (linear / HP filter / first-difference)
2. Goertzel DFT for targeted spectral analysis
3. Bartels test for per-cycle statistical significance
4. Hurst exponent (R/S analysis) for regime classification
5. Composite wave reconstruction from selected cycles

Covers equities, FX, commodities (via FRED), and crypto. Free tier supports daily timeframe analyses.

**Companion open source**
[hurst-calculator](https://github.com/Osamwonyi18/hurst-calculator) — Python library implementing the same R/S methodology used in the platform.

Entry is formatted to match neighbouring lines in the section (no trailing GitHub link, description ends with period).