### PR TITLE
Add GitDealFlow to Commercial & Proprietary Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [ML-Quant](https://www.ml-quant.com/) - Top Quant resources like ArXiv (sanity), SSRN, RePec, Journals, Podcasts, Videos, and Blogs.
 - [RealMarketAPI](https://realmarketapi.com/) - Provides ultra-low latency market data for gold, forex, crypto, and stocks via REST, WebSocket, and MCP—built for speed, reliability, and scale.
 - [Webb Database](https://webb-database.com/) - Aggregates public financial data from HKEX, the SFC, the Hong Law Society, UK Companies House and other sources, has searchable datasets on listed companies, many in machine-readable formats.
+- [GitDealFlow](https://gitdealflow.com) - Alternative-data signal platform ranking early-stage private companies by GitHub stars-per-day, hiring velocity, and package-registry adoption. Free weekly signal report, Chrome extension overlay on Crunchbase/AngelList, and MCP server on npm for LLM agent access.
 
 ## Related Lists
 


### PR DESCRIPTION
Adding **GitDealFlow** under the existing *Commercial & Proprietary Services* section.

### What it is
Alternative-data signal platform that ranks early-stage private companies by GitHub stars-per-day, hiring velocity, and package-registry (npm/PyPI) adoption. Used by VC analysts as a pre-DD filter to surface breakout companies 6-12 months before they appear in traditional databases.

### Why it fits this list
Section neighbors — 13F Insight, VertData, Earnings Feed, ValueRay — are all commercial data/signal APIs serving quant/investor workflows. GitDealFlow slots in as the private-markets / venture-side complement: same alt-data methodology, scoped to early-stage companies rather than public equities.

### Format & guidelines checklist
- [x] One entry added, appended to the end of *Commercial & Proprietary Services*
- [x] Format matches neighbors: `- [Name](url) - Sentence ending with a period.`
- [x] No language backtick tags (consistent with other entries in this section)
- [x] Description is concise, single-purpose
- [x] HTTPS URL
- [x] Product is actively maintained (live site, MCP server published on npm as `@gitdealflow/mcp-signal`)

### Links
- Site: https://gitdealflow.com
- Free weekly signal: https://gitdealflow.com/signals
- Methodology: https://gitdealflow.com/methodology
- MCP server: https://www.npmjs.com/package/@gitdealflow/mcp-signal

Happy to adjust wording or category placement if you'd prefer.