### PR TITLE
Add unirate-api Python client to Market Data & Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [yfi](https://github.com/nickelkr/yfi) - `Python` - Yahoo! YQL library.
 - [chinesestockapi](https://pypi.org/project/chinesestockapi/) - `Python` - Python API to get Chinese stock price. (Last updated: 2015-03-21).
 - [exchange](https://github.com/akarat/exchange) - `Python` - Get current exchange rate.
+- [unirate-api](https://github.com/UniRate-API/unirate-api-python) - `Python` - Client for UniRateAPI providing real-time and historical exchange rates for 170+ fiat and crypto currencies plus VAT rates, with a free tier and no credit card required.
 - [Chart Library](https://github.com/grahammccain/chart-library-mcp) - `Python` - Historical chart pattern similarity search API. 24M+ pre-computed embeddings across 15K+ symbols and 10 years of data using pgvector. Returns forward returns, regime analysis, and pattern detection. Also available as MCP server. [Website](https://chartlibrary.io)
 - [ticks](https://github.com/jamescnowell/ticks) - `Python` - Simple command line tool to get stock ticker data.
 - [pybbg](https://github.com/bpsmith/pybbg) - `Python` - Python interface to Bloomberg COM APIs.


### PR DESCRIPTION
## Summary

Adds the official Python client for **UniRateAPI** to the Market Data & Data Sources section, placed immediately after the existing `[exchange]` entry to keep FX-related items grouped.

## Why it fits

- Free real-time exchange rates for **170+ fiat and crypto currencies**, plus VAT rates
- Free tier with no credit card required (active maintenance, public source on GitHub)
- One-line description in the format required by `parse.py` / CONTRIBUTING.md, ending with a period
- Single-language entry tagged `` `Python` ``

## Verification

- Format matches the parser regex `^\s*- \[(.*)\]\((.*)\) - (.*)$`
- Description is one sentence, ends with a period
- HTTPS URL, links to active GitHub repo with documentation
- Recent activity (commits within the last 12 months — `unirate-api` was last updated this month)

One project per PR per CONTRIBUTING.md. Happy to amend the wording or move it elsewhere in the section if preferred.
