### PR TITLE
Add aurumq-rl to Trading & Backtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [jesse](https://github.com/jesse-ai/jesse) - `Python` - An advanced crypto trading bot written in Python.
 - [rqalpha](https://github.com/ricequant/rqalpha) - `Python` - A extendable, replaceable Python algorithmic backtest && trading framework supporting multiple securities.
 - [FinRL-Library](https://github.com/AI4Finance-LLC/FinRL-Library) - `Python` - A Deep Reinforcement Learning Library for Automated Trading in Quantitative Finance. NeurIPS 2020.
+- [aurumq-rl](https://github.com/yupoet/aurumq-rl) - `Python` - Reinforcement learning stock-selection framework for the China A-share market with multi-source factor input (alpha101 + main-force flow + hot-money seats + northbound + institutional + fundamentals), board-aware price limits, and ONNX CPU inference.
 - [bulbea](https://github.com/achillesrasquinha/bulbea) - `Python` - Deep Learning based Python Library for Stock Market Prediction and Modelling.
 - [ib_nope](https://github.com/ajhpark/ib_nope) - `Python` - Automated trading system for NOPE strategy over IBKR TWS.
 - [OctoBot](https://github.com/Drakkar-Software/OctoBot) - `Python` - Open source cryptocurrency trading bot for high frequency, arbitrage, TA and social trading with an advanced web interface.


### PR DESCRIPTION
## Entry

- [aurumq-rl](https://github.com/yupoet/aurumq-rl) - \`Python\` - Reinforcement learning stock-selection framework for the China A-share market with multi-source factor input (alpha101 + main-force flow + hot-money seats + northbound + institutional + fundamentals), board-aware price limits, and ONNX CPU inference.

## Why this fits

Placed in **Trading & Backtesting** right after FinRL-Library since both are RL-based for trading. AurumQ-RL focuses specifically on the China A-share market and provides:

- A-share-specific constraints (T+1, board-aware price limits — Main ±10% / STAR/ChiNext ±20% / BSE ±30% / ST ±5%)
- Multi-source factor recognition (12 prefix groups: alpha_/mf_/hm_/hk_/inst_/mg_/cyq_/senti_/sh_/fund_/ind_/mkt_)
- Offline GPU training (PPO/A2C/SAC via Stable-Baselines3) + CPU ONNX inference (~150ms per 5000-stock cross-section)
- 115 unit tests, MIT-licensed

## Checklist

- [x] Description ends with a period
- [x] Single-language tag (\`Python\`)
- [x] HTTPS GitHub URL
- [x] Active project (just released v0.1.0)
- [x] README with usage examples + quickstart
- [x] CI (GitHub Actions) configured

## Links

- Repo: https://github.com/yupoet/aurumq-rl
- Release: https://github.com/yupoet/aurumq-rl/releases/tag/v0.1.0
- License: MIT