### PR TITLE
Add StockVektor to Commercial & Proprietary Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [CoinTester](https://cointester.io) - No-code crypto backtesting platform with 100+ indicators, AI sentiment signals, and 5+ years of historical data across 1,000+ trading pairs.
 - [goMacro.ai](https://gomacro.ai) - AI-powered economic calendar with institutional-grade insights, bull/bear/base case scenario planning for NFP, CPI, PPI and other macro data releases.
 - [StockAInsights](https://stockainsights.com) - AI-extracted financial statements API covering SEC filings including foreign filers (20-F, 6-K, 40-F), normalized quarterly and annual data from 2014+.
+- [StockVektor](https://stockvektor.com) - Free stock research web app for ~1,300 US stocks with explainable quality scores (Piotroski F-Score, Altman Z-Score, Beneish M-Score, ROIC, EV/EBIT) computed from SEC EDGAR data, sector-relative metrics, insider buying clusters, 13F super-investor overlap, and activist filing (Schedule 13D/G) tracking.
 - [bolsai](https://usebolsai.com) - REST API and MCP server for Brazilian stock market data (B3). Covers 350+ stocks, 400+ FIIs with fundamentals (27+ indicators), dividends, historical prices, financials, and macro indicators sourced from B3, CVM, and BCB.
 - [brapi.dev](https://brapi.dev/) - Brazilian stock market data API for B3/Bovespa quotes, historical OHLCV, dividends, and fundamentals.
 - [13F Insight](https://13finsight.com/) - Track institutional investor 13F holdings with AI-powered analysis, position change alerts, and filing summaries.


### PR DESCRIPTION
Adds StockVektor to the Commercial & Proprietary Services section, alongside StockAInsights, 13F Insight, and VertData.

StockVektor (https://stockvektor.com) is a free web app that computes Piotroski F-Score, Altman Z-Score, Beneish M-Score, ROIC, and EV/EBIT from SEC EDGAR data for ~1,300 US stocks. Scoring is explainable and sector-relative. Also surfaces insider buying clusters, 13F super-investor overlap, and Schedule 13D/G activist filings.

Useful for quants doing fundamental factor research and looking for a free explainable baseline.