### PR TITLE
Add Oracle3 to Prediction Markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [pmxt](https://github.com/pmxt-dev/pmxt) - `Python` `JavaScript` - The CCXT for prediction markets. A unified API for trading on Polymarket, Kalshi, and more.
 - [PolyMind](https://polyminds.netlify.app/) - `Python` - Real-time Polymarket trading alerts with multi-AI analysis (Groq, Claude, Gemini). Track whale bets, volume spikes, coordinated wallets, and 12 signal types. Free tier available. [GitHub](https://github.com/samirasadov28-code/PolyMind)
 - [prediction-market-maker](https://github.com/octavi42/prediction-market-maker) - `Python` - Open-source market-making strategy that placed #2 in Paradigm's prediction market challenge, with full strategy evolution and analysis.
+- [Oracle3](https://github.com/YichengYang-Ethan/oracle3) - `Python` - Autonomous trading agent for Kalshi, Polymarket, and Solana — Wang Transform pricing (calibrated on 291k resolved contracts) drives eight constraint-based arbitrage strategies and Kelly-sized model trades.
 
 ## Calendars & Market Hours
 


### PR DESCRIPTION
Adding [Oracle3](https://github.com/YichengYang-Ethan/oracle3) to the **Prediction Markets** section.

Oracle3 is an open-source autonomous trading agent that operationalizes the Wang Transform pricing model across multiple prediction-market venues (Kalshi, Polymarket, Solana via DFlow). It complements the existing entries by providing a multi-venue execution agent with explicit constraint-based arbitrage and model-driven strategies.

The pricing engine is backed by a working paper: [Pricing Prediction Markets: Risk Premiums, Incomplete Markets, and a Decomposition Framework](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6468338) (Yang, 2026, UIUC) — λ̂ = 0.183 estimated on 291,309 resolved contracts across 6 platforms.

### Quality
- **License**: Apache 2.0
- **Activity**: v1.1.0 released 2026-05-07; regular commits
- **Documentation**: full [docs site](https://yichengyang-ethan.github.io/oracle3) with tutorials
- **Tests**: 633 tests; mypy + ruff + codespell on every push
- **Stars**: 170+

### Checklist
- [x] Single project per PR
- [x] Format: ``- [Name](url) - `Lang` - Description.``
- [x] Description ends with a period
- [x] Placed under **Prediction Markets** (matches project domain)
- [x] Searched open/closed PRs — no duplicates