### PR TITLE
Add mortgagemath

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [finoptions](https://github.com/bbcho/finoptions-dev) - `Python` - Complete python implementation of R package fOptions with partial implementation of fExoticOptions for pricing various options.
 - [pypme](https://github.com/ymyke/pypme) - `Python` - PME (Public Market Equivalent) calculation.
 - [AbsBox](https://github.com/yellowbean/AbsBox) - `Python` - A Python based library to model cashflow for structured product like Asset-backed securities (ABS) and Mortgage-backed securities (MBS).
+- [mortgagemath](https://github.com/murraystokely/mortgagemath) - `Python` - Cent-accurate mortgage amortization schedules with Decimal arithmetic and published-source validation across six countries.
 - [Intrinsic-Value-Calculator](https://github.com/akashaero/Intrinsic-Value-Calculator) - `Python` - A Python tool for quick calculations of a stock's fair value using Discounted Cash Flow analysis.
 - [Kelly-Criterion](https://github.com/deltaray-io/kelly-criterion) - `Python` - Kelly Criterion implemented in Python to size portfolios based on J. L. Kelly Jr's formula.
 - [rateslib](https://github.com/attack68/rateslib) - `Python` - A fixed income library for pricing bonds and bond futures, and derivatives such as IRS, cross-currency and FX swaps.


### PR DESCRIPTION
## Summary

Adds mortgagemath to Financial Instruments & Pricing.

mortgagemath is an actively maintained Python package for cent-accurate mortgage amortization schedules. It uses Decimal arithmetic and validates published-source examples across six countries, including regulator, servicing-guide, textbook, and calculator schedules.

## Checklist

- One project added
- Entry uses the required language-tag format
- GitHub repository URL used as primary link
- Description is concise and ends with a period