### PR TITLE
Update QuantOracle entry: link to live interactive calculators

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [quantra](https://github.com/joseprupi/quantraserver) - `Python` - High-performance pricing engine built on QuantLib. It exposes QuantLib's functionality through gRPC and REST APIs, enabling distributed computations with FlatBuffers serialization.
 - [optionlab](https://github.com/rgaveiga/optionlab) - `Python` - A Python library for evaluating option trading strategies.
 - [flashalpha](https://github.com/FlashAlpha-lab/flashalpha-python) - `Python` - Python client for the FlashAlpha options analytics API.
-- [QuantOracle](https://github.com/QuantOracledev/quantoracle) - `Python` - Free quant finance API with 63 deterministic endpoints for options pricing, risk analysis, portfolio optimization, Monte Carlo simulation, and technical indicators.
+- [QuantOracle](https://github.com/QuantOracledev/quantoracle) - `Python` - Free quant finance API with 63 deterministic endpoints + 12 free interactive calculators at [quantoracle.dev](https://quantoracle.dev). Options pricing with full Greeks, Monte Carlo, Kelly, VaR, Sharpe, CAGR, crypto liquidation, impermanent loss. 1,000 free calls/day, no API key.
 - [RQuantLib](https://github.com/eddelbuettel/rquantlib) - `R` - RQuantLib connects GNU R with QuantLib.
 - [quantmod](https://cran.r-project.org/web/packages/quantmod/index.html) - `R` - Quantitative Financial Modelling Framework. [GitHub](https://github.com/joshuaulrich/quantmod)
 - [Rmetrics](https://www.rmetrics.org) - `R` - The premier open source software solution for teaching and training quantitative finance.


### PR DESCRIPTION
The [QuantOracle entry](https://github.com/wilsonfreitas/awesome-quant?tab=readme-ov-file#numerical-libraries--data-structures-3) (originally added in #340) recently launched a companion site at [quantoracle.dev](https://quantoracle.dev) with 12 free interactive calculators backed by the same API:

- Black-Scholes (with full Greeks)
- American Option (binomial tree)
- Options Profit (multi-leg payoff)
- Implied Volatility
- Monte Carlo Simulation (with retirement / 4% rule presets)
- Kelly Criterion
- Position Size
- Value at Risk + CVaR
- Sharpe Ratio (with confidence interval)
- CAGR (with forward projections)
- Crypto Liquidation Price
- Impermanent Loss

Updating the entry so readers can try the math in-browser without writing client code. Same one-line entry, just adds the live URL.

Diff is +1 / -1 line.