### PR TITLE
Add Sharpe to commercial quant services

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [ML-Quant](https://www.ml-quant.com/) - Top Quant resources like ArXiv (sanity), SSRN, RePec, Journals, Podcasts, Videos, and Blogs.
 - [RealMarketAPI](https://realmarketapi.com/) - Provides ultra-low latency market data for gold, forex, crypto, and stocks via REST, WebSocket, and MCP—built for speed, reliability, and scale.
 - [The Stock Radar](https://thestockradar.com) - Daily multi-language stock movers, technical analysis, earnings recaps, and weekly research reports across 6 markets (US, Korea, Japan, Taiwan, India, Germany) published in 6 languages.
+- [Sharpe](https://www.sharpe.ai/) - AI-driven crypto trading intelligence terminal for derivatives positioning, DEX flow, on-chain risk, narrative rotation, token discovery, and agent-ready market data.
 - [Webb Database](https://webb-database.com/) - Aggregates public financial data from HKEX, the SFC, the Hong Law Society, UK Companies House and other sources, has searchable datasets on listed companies, many in machine-readable formats.
 - [GitDealFlow](https://gitdealflow.com) - Alternative-data signal platform ranking early-stage private companies by GitHub stars-per-day, hiring velocity, and package-registry adoption. Free weekly signal report, Chrome extension overlay on Crunchbase/AngelList, and MCP server on npm for LLM agent access.
 


### PR DESCRIPTION
## Summary
Adds Sharpe to the Commercial & Proprietary Services section.

## Why this fits
The section already includes hosted and commercial quant platforms alongside open-source research tooling elsewhere in the list. Sharpe fits this section as a crypto market intelligence terminal rather than as a library, backtester, or academic dataset.

## Change
- Added one README entry for Sharpe.
- Kept the entry in the existing bullet format used by the section.
- Linked the canonical website URL: https://www.sharpe.ai/

## Validation
- Confirmed the branch diff is one README-only insertion.
- Confirmed https://www.sharpe.ai/ resolves.
- Checked existing pull requests and issues for `sharpe.ai` before opening this PR.

Disclosure: I work on Sharpe.
