### PR TITLE
Add Bilig to spreadsheet integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 
 ## Excel & Spreadsheet Integration
 
+- [Bilig](https://github.com/proompteng/bilig) - `TypeScript` - Formula WorkPaper and XLSX recalculation runtime for Node.js services and agent tools.
 - [xlwings](https://www.xlwings.org/) - `Python` - Make Excel fly with Python. [GitHub](https://github.com/xlwings/xlwings)
 - [openpyxl](https://openpyxl.readthedocs.io/en/latest/) - `Python` - Read/Write Excel 2007 xlsx/xlsm files.
 - [xlrd](https://github.com/python-excel/xlrd) - `Python` - Library for developers to extract data from Microsoft Excel spreadsheet files.


### PR DESCRIPTION
## Summary

Adds Bilig to the Excel & Spreadsheet Integration section.

Bilig is an active TypeScript library for formula WorkPapers and XLSX recalculation in Node.js services and agent tools. It fits the section because it targets server-side workbook/formula workflows rather than Excel UI automation.

## Checklist

- One project added
- Entry uses a GitHub repository URL
- Entry includes a language tag
- Description is one sentence and ends with a period
- Checked the README and existing PRs for a Bilig duplicate
