### PR TITLE
Add AlgoVault to Trading & Backtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [fin-primitives](https://github.com/Mattbusel/fin-primitives) - `Rust` - Financial market primitives in Rust: Price/Quantity/Symbol newtypes, BTreeMap order book, OHLCV aggregation, SMA/EMA/RSI indicators, position ledger with PnL, and composable risk monitor.
 
 ## Trading & Backtesting
+- [AlgoVault](https://github.com/AlgoVaultLabs/crypto-quant-signal-mcp) - `TypeScript` - MCP server returning composite crypto trade verdicts (direction, confidence, regime) across 5 perpetual-futures venues, with cross-venue funding-rate arbitrage and an on-chain Merkle-verified track record. Free tier.
 - [income-desk](https://github.com/nitinblue/income-desk) - `Python` - Systematic options trading intelligence for small accounts with desk-based portfolio management, pre-trade validation, and multi-broker consolidation.
 
 - [AI Quant Agents](https://github.com/demandai/ai-quant-agents) - `Python` - Multi-agent LLM trading analysis where 12 AI agents (analysts, debaters, risk manager) debate stock picks in real-time, supporting US equities and China A-shares.


### PR DESCRIPTION
Adds **AlgoVault** (`crypto-quant-signal-mcp`) to **Trading & Backtesting**.

An MCP server that returns composite crypto trade verdicts — direction, confidence, and market regime — across 5 perpetual-futures venues, plus cross-venue funding-rate arbitrage. Built for AI agents and quant workflows; the protocol is the API (no SDK).

- Real install base + active maintenance — published on npm: https://www.npmjs.com/package/crypto-quant-signal-mcp
- Verifiable track record — every call Merkle-anchored on Base L2: https://algovault.com/track-record
- Free tier — 100 calls/month, no card.

Repo: https://github.com/AlgoVaultLabs/crypto-quant-signal-mcp · format-matched, no drifting numbers. Thanks!