### PR TITLE
Add Finterm to Commercial & Proprietary Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Sharpe](https://www.sharpe.ai/) - AI-driven crypto trading intelligence terminal for derivatives positioning, DEX flow, on-chain risk, narrative rotation, token discovery, and agent-ready market data.
 - [Webb Database](https://webb-database.com/) - Aggregates public financial data from HKEX, the SFC, the Hong Law Society, UK Companies House and other sources, has searchable datasets on listed companies, many in machine-readable formats.
 - [GitDealFlow](https://gitdealflow.com) - Alternative-data signal platform ranking early-stage private companies by GitHub stars-per-day, hiring velocity, and package-registry adoption. Free weekly signal report, Chrome extension overlay on Crunchbase/AngelList, and MCP server on npm for LLM agent access.
-- [Finterm](https://finterm.xyz) - Keyboard-first browser-based financial terminal with live stock and crypto charts, SEC EDGAR fundamentals, funding rates, liquidations, news, and a strategy backtester. Free, no login required.
+- [Finterm](https://finterm.xyz) - `TypeScript` - Browser-based, keyboard-first financial terminal. No public GitHub repo (closed source).
 
 ## Related Lists
 

--- a/README.md
+++ b/README.md
@@ -637,6 +637,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Sharpe](https://www.sharpe.ai/) - AI-driven crypto trading intelligence terminal for derivatives positioning, DEX flow, on-chain risk, narrative rotation, token discovery, and agent-ready market data.
 - [Webb Database](https://webb-database.com/) - Aggregates public financial data from HKEX, the SFC, the Hong Law Society, UK Companies House and other sources, has searchable datasets on listed companies, many in machine-readable formats.
 - [GitDealFlow](https://gitdealflow.com) - Alternative-data signal platform ranking early-stage private companies by GitHub stars-per-day, hiring velocity, and package-registry adoption. Free weekly signal report, Chrome extension overlay on Crunchbase/AngelList, and MCP server on npm for LLM agent access.
+- [Finterm](https://finterm.xyz) - Keyboard-first browser-based financial terminal with live stock and crypto charts, SEC EDGAR fundamentals, funding rates, liquidations, news, and a strategy backtester. Free, no login required.
 
 ## Related Lists
 


### PR DESCRIPTION
Adds **Finterm** (https://finterm.xyz) under **Commercial & Proprietary Services**.

Finterm is a free, keyboard-first browser-based financial terminal: live stock and crypto charts, SEC EDGAR fundamentals (it pivots companyfacts into quarterly statements), funding rates, liquidations, news, and a strategy backtester. No login required.

- It's a hosted proprietary web app with no public GitHub repo, so per CONTRIBUTING it belongs in **Commercial & Proprietary Services** (alongside similar entries like StockVektor).
- One project; entry format matches the section (commercial site link + one-sentence description ending with a period).
- Not a duplicate of any existing entry.