### PR TITLE
Add TWZRD Agent Intel: on-chain trust MCP server for AI agents executing crypto transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [fin-stream](https://github.com/Mattbusel/fin-stream) - `Rust` - Real-time market data streaming in Rust: lock-free SPSC ring buffer, 100K+ ticks/second ingestion, multi-timeframe OHLCV construction, and Lorentz transforms on financial time series.
 - [finalytics](https://github.com/Nnamdi-sys/finalytics) - `Rust` - A rust library for financial data analysis.
 - [Coinugget](https://coinugget.com) - `Web` - Real-time RSI signals, price action & volume spikes dashboard across multiple exchanges. Free, no sign-up required.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - `Web` - On-chain trust intelligence MCP server for AI agents executing Solana crypto transactions. Tools: `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt` (free); `get_trust_receipt` returns a signed V5 receipt via x402 USDC micropayment (<1s Solana settlement). Zero-install: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`
 
 
 ## Prediction Markets


### PR DESCRIPTION
Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) — MCP server providing on-chain trust scoring for AI agents operating with Solana payments.

AI agents call \`preflight_check\` before dispatching transactions, \`score_agent\` to query trust scores, and \`get_trust_receipt\` to mint a signed V5 receipt (paid via x402 USDC micropayment, <1s Solana settlement).

Zero-install: \`{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}\`

Added to the **Market Data & Data Sources** section alongside other API/MCP tools (e.g. `PreReason MCP`). TWZRD provides the trust intelligence layer that quant/trading AI agents need when executing autonomous Solana transactions — it complements the trading agents and crypto data tools already in this list.