### PR TITLE
feat: The Stall — 277 pay-per-call AI capabilities via x402 (v4.64.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [GitDealFlow](https://gitdealflow.com) - Alternative-data signal platform ranking early-stage private companies by GitHub stars-per-day, hiring velocity, and package-registry adoption. Free weekly signal report, Chrome extension overlay on Crunchbase/AngelList, and MCP server on npm for LLM agent access.
 - [Finterm](https://finterm.xyz) - `TypeScript` - Browser-based, keyboard-first financial terminal. No public GitHub repo (closed source).
 - [Coinugget](https://coinugget.com) - Real-time RSI signals, price action, and volume spikes dashboard across multiple exchanges. Free, no sign-up required.
+- [The Stall](https://the-stall.intuitek.ai) - `JavaScript` - 277 pay-per-call tools via MCP: US stocks, crypto, DeFi analytics, Polymarket prediction markets, macro data, and sanctions screening. USDC on Base. No API key required. [GitHub](https://github.com/thebrierfox/the-stall)
 
 ## Related Lists
 


### PR DESCRIPTION
## The Stall — 210 pay-per-call AI capabilities (v4.64.0)

**Live:** https://the-stall.intuitek.ai | **MCP:** https://the-stall.intuitek.ai/mcp

The Stall is an x402 MCP server with 210 pay-per-call capabilities — AI agents pay USDC per call, no API keys needed.

**Coverage:** stocks, crypto, DeFi, insider trades, Form 144 planned sales, options, macro, congressional trades, weather, cron tools, domain intel, and 185+ more.

**New in v4.64.0:**
- `form-144-intel` — SEC Form 144 planned insider sale filings (pre-Form 4 signal, from EDGAR)
- `cron-parser` — parse and explain cron expressions, return next N run times

```json
{
  "mcpServers": {
    "the-stall": {
      "type": "streamable-http",
      "url": "https://the-stall.intuitek.ai/mcp"
    }
  }
}
```

git: d25c40a | version: v4.64.0 | caps: 210
