### PR TITLE
Add two Bitget-focused Python tools under Trading & Backtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [TradeClaw](https://github.com/naimkatiman/tradeclaw) - `Node.js` `TypeScript` - Open-source self-hosted AI trading signal platform. Generates buy/sell signals using RSI, MACD, EMA, Bollinger Bands for forex, crypto and commodities. Deployable via Docker Compose. ([Demo](https://tradeclaw.win/dashboard))
 - [ShowMe](https://github.com/nazmiefearmutcu/showMe) - `Python` `Rust` `TypeScript` - Open-source native macOS market cockpit. 12-timeframe consensus scan across 3370 symbols (crypto + equity + ETF + FX + commodity + bond), 23 technical indicators with per-market calibration, real WebSocket streaming. Tauri shell + Python sidecar (FastAPI) + React UI; 110+ exchanges via ccxt.
 - [TBV1](https://github.com/nazmiefearmutcu/TRADING-BOT) - `Python` - Crypto perpetual-futures bot with a 7-tab web dashboard and a 15-indicator consensus engine voting across 12 timeframes (1m → 1d). Paper-mode by default. Includes packaged macOS reference build and Windows distribution.
+- [analyseur-crypto](https://github.com/alexch03/analyseur-crypto) - `Python` - Multi-timeframe crypto market structure analyzer for Bitget with rule-based BOS/CHOCH/FVG/order block detection, paper trading engine, FastAPI dashboard, Telegram bot, and 206 unit tests.
+- [bitget-sma-bot](https://github.com/alexch03/bitget-sma-bot) - `Python` - Hackable Bitget USDT-M perpetuals trading bot with SMA, Bollinger Bands, and RSI strategies, supporting paper/dry/demo/live modes, Flask web UI, Telegram alerts, and a grid optimizer.
 
 ## Portfolio Optimization & Risk Analysis
 


### PR DESCRIPTION
Hi @wilsonfreitas — adding two complementary open-source projects I authored that target the Bitget USDT-M perpetuals market. Following the CONTRIBUTING guideline that allows *multiple tools from the same author with complementary functionality* in a single PR.

### Entries added (both under `## Trading & Backtesting`)

**[analyseur-crypto](https://github.com/alexch03/analyseur-crypto)** — `Python` — Multi-timeframe crypto market structure analyzer for Bitget with rule-based BOS/CHOCH/FVG/order block detection, paper trading engine, FastAPI dashboard, Telegram bot, and 206 unit tests.

**[bitget-sma-bot](https://github.com/alexch03/bitget-sma-bot)** — `Python` — Hackable Bitget USDT-M perpetuals trading bot with SMA, Bollinger Bands, and RSI strategies, supporting paper/dry/demo/live modes, Flask web UI, Telegram alerts, and a grid optimizer.

### Why both in one PR
- **Same author** (alexch03).
- **Complementary functionality** — one is a market-structure analyzer (research / signal generation), the other is a strategy executor (live/paper execution). They share the same target exchange (Bitget).
- Both are MIT-licensed, active (pushed today), Python 3.10+, documented with bilingual (EN/FR) READMEs.

### Format check
- ✅ Entry format: `- [name](github-url) - \`Python\` - One-sentence description ending with a period.`
- ✅ Category: `## Trading & Backtesting` (Python trading/backtesting libraries).
- ✅ Active (commits within last 12 months — both pushed today).
- ✅ Documented READMEs with usage examples.
- ✅ HTTPS URLs only.
- ✅ Not duplicates (searched the list and recent PRs).

Happy to split into two PRs if you prefer one-project-per-PR — just let me know.