### PR TITLE
Add purgedcv to Trading & Backtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [fin-primitives](https://github.com/Mattbusel/fin-primitives) - `Rust` - Financial market primitives in Rust: Price/Quantity/Symbol newtypes, BTreeMap order book, OHLCV aggregation, SMA/EMA/RSI indicators, position ledger with PnL, and composable risk monitor.
 
 ## Trading & Backtesting
+- [purgedcv](https://github.com/eslazarev/purged-cross-validation) - `Python` - scikit-learn-compatible purged, group-purged, and combinatorial purged (CPCV) cross-validation, walk-forward splitting, and backtest-overfitting statistics (deflated and probabilistic Sharpe ratios, PBO, minimum backtest length) to prevent leakage and overfitting when backtesting trading strategies.
 - [income-desk](https://github.com/nitinblue/income-desk) - `Python` - Systematic options trading intelligence for small accounts with desk-based portfolio management, pre-trade validation, and multi-broker consolidation.
 
 - [AI Quant Agents](https://github.com/demandai/ai-quant-agents) - `Python` - Multi-agent LLM trading analysis where 12 AI agents (analysts, debaters, risk manager) debate stock picks in real-time, supporting US equities and China A-shares.


### PR DESCRIPTION
Adds [`purgedcv`](https://github.com/eslazarev/purged-cross-validation) under **Trading & Backtesting**.

It is a scikit-learn-compatible library for purged, group-purged, and combinatorial purged (CPCV) cross-validation, walk-forward splitting, and backtest-overfitting statistics (Deflated and Probabilistic Sharpe Ratio, PBO, Minimum Backtest Length, Minimum Track Record Length), implementing the methods from Lopez de Prado's *Advances in Financial Machine Learning* and Bailey & Lopez de Prado. It is meant to prevent leakage and overfitting when validating and backtesting trading strategies.

- `Python`, MIT-licensed, on PyPI.
- Entry follows the CONTRIBUTING single-language format and ends with a period.
- I am the package author.