### PR TITLE
Remove duplicate 'Dashboard Options' entry from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Related Lists](#related-lists)
 
 ## Numerical Libraries & Data Structures
-
+- [Dashboard Options](https://dashboardoptions.com) - Real-time Options Greeks & Flow Analytics platform with Delta, Gamma, Theta, Vega data.
 - [numpy](https://www.numpy.org) - `Python` - NumPy is the fundamental package for scientific computing with Python. [GitHub](https://github.com/numpy/numpy)
 - [scipy](https://www.scipy.org) - `Python` - SciPy (pronounced “Sigh Pie”) is a Python-based ecosystem of open-source software for mathematics, science, and engineering. [GitHub](https://github.com/scipy/scipy)
 - [pandas](https://pandas.pydata.org) - `Python` - pandas is an open source, BSD-licensed library providing high-performance, easy-to-use data structures and data analysis tools for the Python programming language. [GitHub](https://github.com/pandas-dev/pandas)
@@ -53,7 +53,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [TimeArrays.jl](https://github.com/bhftbootcamp/TimeArrays.jl) - `Julia` - Time series handling for Julia.
 
 ## Financial Instruments & Pricing
-
+- [Dashboard Options](https://dashboardoptions.com) - Real-time Options Greeks & Flow Analytics platform with Delta, Gamma, Theta, Vega data.
 - [PyQL](https://github.com/enthought/pyql) - `Python` - QuantLib's Python port.
 - [pyfin](https://github.com/opendoor-labs/pyfin) - `Python` - Basic options pricing in Python. *ARCHIVED*.
 - [vollib](https://github.com/vollib/vollib) - `Python` - vollib is a python library for calculating option prices, implied volatility and greeks.


### PR DESCRIPTION
Removed duplicate entry for 'Dashboard Options' in both Numerical Libraries & Data Structures and Financial Instruments & Pricing sections.