### PR TITLE
Add Factor Weave to Market Data & Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [fin-stream](https://github.com/Mattbusel/fin-stream) - `Rust` - Real-time market data streaming in Rust: lock-free SPSC ring buffer, 100K+ ticks/second ingestion, multi-timeframe OHLCV construction, and Lorentz transforms on financial time series.
 - [finalytics](https://github.com/Nnamdi-sys/finalytics) - `Rust` - A rust library for financial data analysis.
 - [Coinugget](https://coinugget.com) - `Web` - Real-time RSI signals, price action & volume spikes dashboard across multiple exchanges. Free, no sign-up required.
+- [Factor Weave](https://factorweave.com/) - `Python` - Factor scores, similarity search, and leak-free + survivor-free forward-return labels for 14,684 tickers across equities, ETFs, indices, FX, crypto & futures; REST + MCP, Python/TS/R SDKs, free tier.
 
 
 ## Prediction Markets


### PR DESCRIPTION
Adds Factor Weave under Market Data & Data Sources.

Quant-factor data API for 14,684 tickers across equities, ETFs, indices, FX, crypto & futures — factor scores, four similarity methods, and leak-free + survivor-free, total-return forward-return labels. REST + MCP server, with Python/TypeScript/R SDKs. Free tier (250 calls/day, no card).

- Site: https://factorweave.com/
- Tools/SDKs: https://github.com/Blazing-Customs/factorweave-tools
- Methodology (leak-free/survivor-free audit): https://factorweave.com/research.html