### PR TITLE
Add mx-trader-bridge to Trading & Backtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 ## Trading & Backtesting
 - [income-desk](https://github.com/nitinblue/income-desk) - `Python` - Systematic options trading intelligence for small accounts with desk-based portfolio management, pre-trade validation, and multi-broker consolidation.
 
+- [mx-trader-bridge](https://github.com/27dream/mx-trader-bridge) - `Python` - AI auto-trading bridge for East Money's miaoxiang (妙想) China A-share simulation platform; BYOK multi-LLM (OpenAI/DeepSeek/Moonshot/GLM/Qwen) decision brain → automated order placement via miaoxiang API, with daily cron review and weekly AI reflection.
+
 - [AI Quant Agents](https://github.com/demandai/ai-quant-agents) - `Python` - Multi-agent LLM trading analysis where 12 AI agents (analysts, debaters, risk manager) debate stock picks in real-time, supporting US equities and China A-shares.
 - [TradeSight](https://github.com/rmbell09-lang/tradesight) - `Python` - Self-hosted AI trading platform with strategy evolution, technical analysis, backtesting, and paper trading via Alpaca.
 - [Orallexa](https://github.com/alex-jb/orallexa-ai-trading-agent) - `Python` - AI trading operating system with 9 ML models (RF, XGBoost, EMAformer, MOIRAI-2, Chronos-2, DDPM, PPO RL, GNN, LR) ranked by Sharpe ratio, Claude AI synthesis with dual-tier routing (~$0.003/analysis), real-time Next.js dashboard, Alpaca paper trading, and 277 automated tests.


### PR DESCRIPTION
## What

Adding [mx-trader-bridge](https://github.com/27dream/mx-trader-bridge) — an AI auto-trading bridge for East Money's miaoxiang (妙想) China A-share simulation platform.

## Why

- BYOK multi-LLM (OpenAI / DeepSeek / Moonshot / GLM / Qwen) decision brain → automated order placement via miaoxiang API
- Daily cron post-market review + weekly AI reflection loop
- Pure Python + Flask, fully local, zero cloud cost
- Fills a gap in the list for AI-driven A-share execution tooling

Thanks for maintaining this great list! 🙏