### PR TITLE
Add GreeksLab — free options Greeks calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [optionlab](https://github.com/rgaveiga/optionlab) - `Python` - A Python library for evaluating option trading strategies.
 - [flashalpha](https://github.com/FlashAlpha-lab/flashalpha-python) - `Python` - Python client for the FlashAlpha options analytics API.
 - [QuantOracle](https://github.com/QuantOracledev/quantoracle) - `Python` - Free quant finance API with 63 deterministic endpoints + 12 free interactive calculators at [quantoracle.dev](https://quantoracle.dev). Options pricing with full Greeks, Monte Carlo, Kelly, VaR, Sharpe, CAGR, crypto liquidation, impermanent loss. 1,000 free calls/day, no API key.
+- [GreeksLab](https://greekslab.launchyard.app) - Free options Greeks calculator with Black-Scholes model, implied volatility calculator, strategy builder, and P&L chart.
 - [RQuantLib](https://github.com/eddelbuettel/rquantlib) - `R` - RQuantLib connects GNU R with QuantLib.
 - [quantmod](https://cran.r-project.org/web/packages/quantmod/index.html) - `R` - Quantitative Financial Modelling Framework. [GitHub](https://github.com/joshuaulrich/quantmod)
 - [Rmetrics](https://www.rmetrics.org) - `R` - The premier open source software solution for teaching and training quantitative finance.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [optionlab](https://github.com/rgaveiga/optionlab) - `Python` - A Python library for evaluating option trading strategies.
 - [flashalpha](https://github.com/FlashAlpha-lab/flashalpha-python) - `Python` - Python client for the FlashAlpha options analytics API.
 - [QuantOracle](https://github.com/QuantOracledev/quantoracle) - `Python` - Free quant finance API with 63 deterministic endpoints + 12 free interactive calculators at [quantoracle.dev](https://quantoracle.dev). Options pricing with full Greeks, Monte Carlo, Kelly, VaR, Sharpe, CAGR, crypto liquidation, impermanent loss. 1,000 free calls/day, no API key.
-- [GreeksLab](https://greekslab.launchyard.app) - `JavaScript` - Free options Greeks calculator with Black-Scholes model, implied volatility calculator, strategy builder, and P&L chart.
+- [GreeksLab](https://greekslab.launchyard.app) - `JavaScript` - Free options Greeks calculator covering Delta, Gamma, Theta, Vega, Rho, implied volatility, multi-leg strategy builder, and P&L charts. [GitHub](https://github.com/greekslab/greekslab)
 - [RQuantLib](https://github.com/eddelbuettel/rquantlib) - `R` - RQuantLib connects GNU R with QuantLib.
 - [quantmod](https://cran.r-project.org/web/packages/quantmod/index.html) - `R` - Quantitative Financial Modelling Framework. [GitHub](https://github.com/joshuaulrich/quantmod)
 - [Rmetrics](https://www.rmetrics.org) - `R` - The premier open source software solution for teaching and training quantitative finance.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [optionlab](https://github.com/rgaveiga/optionlab) - `Python` - A Python library for evaluating option trading strategies.
 - [flashalpha](https://github.com/FlashAlpha-lab/flashalpha-python) - `Python` - Python client for the FlashAlpha options analytics API.
 - [QuantOracle](https://github.com/QuantOracledev/quantoracle) - `Python` - Free quant finance API with 63 deterministic endpoints + 12 free interactive calculators at [quantoracle.dev](https://quantoracle.dev). Options pricing with full Greeks, Monte Carlo, Kelly, VaR, Sharpe, CAGR, crypto liquidation, impermanent loss. 1,000 free calls/day, no API key.
-- [GreeksLab](https://greekslab.launchyard.app) - Free options Greeks calculator with Black-Scholes model, implied volatility calculator, strategy builder, and P&L chart.
+- [GreeksLab](https://greekslab.launchyard.app) - `JavaScript` - Free options Greeks calculator with Black-Scholes model, implied volatility calculator, strategy builder, and P&L chart.
 - [RQuantLib](https://github.com/eddelbuettel/rquantlib) - `R` - RQuantLib connects GNU R with QuantLib.
 - [quantmod](https://cran.r-project.org/web/packages/quantmod/index.html) - `R` - Quantitative Financial Modelling Framework. [GitHub](https://github.com/joshuaulrich/quantmod)
 - [Rmetrics](https://www.rmetrics.org) - `R` - The premier open source software solution for teaching and training quantitative finance.


### PR DESCRIPTION
GreeksLab is a free web-based options calculator covering Black-Scholes Greeks (Delta, Gamma, Theta, Vega, Rho), implied volatility, multi-leg strategy builder, and P&L charts. No signup required.