### PR TITLE
Add capitalcom-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 
 ## Trading & Backtesting
 - [AlgoVault](https://github.com/AlgoVaultLabs/crypto-quant-signal-mcp) - `TypeScript` - MCP server returning composite crypto trade verdicts (direction, confidence, regime) across 5 perpetual-futures venues, with cross-venue funding-rate arbitrage and an on-chain Merkle-verified track record. Free tier.
+- [capitalcom-cli](https://github.com/SimonTarara62/capitalcom-cli) - `Python` - Unofficial CLI and async SDK for the Capital.com broker API: market data, guarded order execution, and real-time streaming.
 - [income-desk](https://github.com/nitinblue/income-desk) - `Python` - Systematic options trading intelligence for small accounts with desk-based portfolio management, pre-trade validation, and multi-broker consolidation.
 
 - [mx-trader-bridge](https://github.com/27dream/mx-trader-bridge) - `Python` - AI auto-trading bridge for East Money's miaoxiang (妙想) China A-share simulation platform; BYOK multi-LLM (OpenAI/DeepSeek/Moonshot/GLM/Qwen) decision brain → automated order placement via miaoxiang API, with daily cron review and weekly AI reflection.


### PR DESCRIPTION
Adds **capitalcom-cli** to *Trading & Backtesting* (Python).

[capitalcom-cli](https://github.com/SimonTarara62/capitalcom-cli) is an unofficial, open-source (Apache-2.0) command-line client and async SDK for the Capital.com broker Open API — market data, accounts, watchlists, guarded order execution (two-phase preview→execute with a risk engine), and real-time WebSocket streaming. Published on PyPI, CI-tested across Linux/Windows × Python 3.10–3.12. It fills a gap: Capital.com isn't currently represented in the list, alongside other broker-API tools like alpaca-trade-api.

Single entry, formatted to match the section.