### PR TITLE
Add Superhighway to Market Data & Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 
 ## Market Data & Data Sources
 - [BTC Orderbook Microstructure Research](https://github.com/whoareunot/btc-orderbook-research) - `Jupyter Notebook` - statistical analysis of Binance BTC/USDT orderbook: OBI, CVD, spread.  
+- [Superhighway](https://superhighway.walls.sh) - `Python` - Web search API for AI agents: search, news, scrape, and company research endpoints. Useful for pulling live financial news, analyst coverage, earnings previews, and scraping investor-relations data. Pay-per-call with USDC via x402 or free API key. See the [financial research agent guide](https://superhighway.walls.sh/guides/financial-research-agent).
 - [OpenBB Terminal](https://github.com/OpenBB-finance/OpenBBTerminal) - `Python` - Terminal for investment research for everyone.
 - [Fincept Terminal](https://github.com/Fincept-Corporation/FinceptTerminal) - `Python` - Advance Data Based A.I Terminal for all Types of Financial Asset Research.
 - [yfinance](https://github.com/ranaroussi/yfinance) - `Python` - Yahoo! Finance market data downloader (+faster Pandas Datareader).


### PR DESCRIPTION
Adds [Superhighway](https://superhighway.walls.sh) to the **Market Data & Data Sources** section.

Superhighway is a web search API for AI agents with `search`, `news`, `scrape`, and company `research` endpoints. For quant/finance workflows it's useful for pulling live financial news, analyst coverage, earnings previews, and scraping investor-relations pages. Pay-per-call with USDC via x402, or a free API key.

There's also a worked Python example: [Build a financial research agent](https://superhighway.walls.sh/guides/financial-research-agent).

Entry follows the list's format (`Python` language tag, website link with description ending in a period). Fits alongside existing API/MCP data-source entries in this section.