### PR TITLE
Add tessera-api to Market Data & Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [market-prices](https://github.com/maread99/market_prices) - `Python` - Create meaningful OHLCV datasets from knowledge of [exchange-calendars](https://github.com/gerrymanoim/exchange_calendars) (works out-the-box with data from Yahoo Finance).
 - [tardis-python](https://github.com/tardis-dev/tardis-python) - `Python` - Python interface for Tardis.dev high frequency crypto market data.
 - [lake-api](https://github.com/crypto-lake/lake-api) - `Python` - Python interface for Crypto Lake high frequency crypto market data.
+- [tessera-api](https://github.com/tesseralytics/python-client) - `Python` - Official client for Tessera: order-flow-enriched OHLCV, funding-rate, and positioning datasets built from raw Hyperliquid trades, read straight into Polars or DuckDB over a REST API. [Website](https://tesseralytics.dev)
 - [tessa](https://github.com/ymyke/tessa) - `Python` - simple, hassle-free access to price information of financial assets (currently based on yfinance and pycoingecko), including search and a symbol class.
 - [pandaSDMX](https://github.com/dr-leo/pandaSDMX) - `Python` - Python package that implements SDMX 2.1 (ISO 17369:2013), a format for exchange of statistical data and metadata used by national statistical agencies, central banks, and international organisations.
 - [cif](https://github.com/LenkaV/CIF) - `Python` - Python package that include few composite indicators, which summarize multidimensional relationships between individual economic indicators.


### PR DESCRIPTION
Adds a single entry under **Market Data & Data Sources** for `tessera-api`.

- **Project:** [tessera-api](https://github.com/tesseralytics/python-client) — the official open-source (GPLv3) Python client for Tessera.
- **What it does:** Order-flow-enriched OHLCV, funding-rate, and positioning datasets built from raw Hyperliquid trades, delivered as Parquet over a REST API and read straight into Polars `LazyFrame`s or DuckDB relations (predicate/projection pushdown, no temp files).
- **Section rationale:** Crypto high-frequency market-data client, placed alongside `tardis-python` and `lake-api`.
- **Format:** GitHub repo as the main link (per CONTRIBUTING), single-sentence description ending in a period, `[Website]` appended.
- One project, no duplicate (no existing Tessera/Hyperliquid entry), active and documented.