### PR TITLE
Add FAIG to Trading & Backtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [fin-primitives](https://github.com/Mattbusel/fin-primitives) - `Rust` - Financial market primitives in Rust: Price/Quantity/Symbol newtypes, BTreeMap order book, OHLCV aggregation, SMA/EMA/RSI indicators, position ledger with PnL, and composable risk monitor.
 
 ## Trading & Backtesting
+- [FAIG](https://github.com/tg12/FAIG) - `Python` - Fully automated trading bot for the IG Index platform (spread betting and CFDs), supporting demo and live accounts.
 - [income-desk](https://github.com/nitinblue/income-desk) - `Python` - Systematic options trading intelligence for small accounts with desk-based portfolio management, pre-trade validation, and multi-broker consolidation.
 
 - [AI Quant Agents](https://github.com/demandai/ai-quant-agents) - `Python` - Multi-agent LLM trading analysis where 12 AI agents (analysts, debaters, risk manager) debate stock picks in real-time, supporting US equities and China A-shares.


### PR DESCRIPTION
### FAIG — Fully Automated IG Index trading

Adds **FAIG (Fully Automated IG)** to Trading & Backtesting.

- Automated trading bot for the **IG Index** platform (spread betting / CFDs)
- Works with both **demo and live** accounts via the IG REST API
- Cross-platform (Linux/Windows), Python 3, config-driven

Source: https://github.com/tg12/FAIG  ·  Actively used, 150+ stars.

Entry follows the `- [Name](url) - \`Python\` - description.` format from CONTRIBUTING.
