### PR TITLE
Add AlphaForge and alpha-forge-mcp to quant tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [fin-primitives](https://github.com/Mattbusel/fin-primitives) - `Rust` - Financial market primitives in Rust: Price/Quantity/Symbol newtypes, BTreeMap order book, OHLCV aggregation, SMA/EMA/RSI indicators, position ledger with PnL, and composable risk monitor.
 
 ## Trading & Backtesting
+- [alpha-forge-mcp](https://github.com/alforge-labs/alpha-forge-mcp) - `Python` - MCP server wrapping the AlphaForge CLI for AI-agent-native backtesting, Optuna TPE optimization, and walk-forward testing of trading strategies from Claude Desktop, Cursor, or Claude Code.
 - [income-desk](https://github.com/nitinblue/income-desk) - `Python` - Systematic options trading intelligence for small accounts with desk-based portfolio management, pre-trade validation, and multi-broker consolidation.
 
 - [AI Quant Agents](https://github.com/demandai/ai-quant-agents) - `Python` - Multi-agent LLM trading analysis where 12 AI agents (analysts, debaters, risk manager) debate stock picks in real-time, supporting US equities and China A-shares.
@@ -608,6 +609,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 
 ## Commercial & Proprietary Services
 
+- [AlphaForge](https://alforgelabs.com) - Local-first agent-native quant CLI with Optuna TPE optimization, walk-forward testing, anti-overfitting guards, and TradingView Pine v6 code generation. Free trial available. [GitHub](https://github.com/alforge-labs/alpha-forge-mcp)
 - [Chartscout](https://chartscout.io) - Real-time cryptocurrency chart pattern detection with automated alerts across multiple exchanges.
 - [DayTradingBench](https://daytradingbench.com) - Live autonomous benchmark that evaluates LLM trading performance on DAX and Nasdaq indices using identical strategies and real-time market data. API access available.
 - [CoinTester](https://cointester.io) - No-code crypto backtesting platform with 100+ indicators, AI sentiment signals, and 5+ years of historical data across 1,000+ trading pairs.


### PR DESCRIPTION
Adds two related entries from the AlphaForge ecosystem:

  - **alpha-forge-mcp** (OSS, Apache-2.0) → **Trading & Backtesting** — an MCP server that lets AI
  agents (Claude Desktop, Cursor, Claude Code) drive the AlphaForge quant CLI: backtests, Optuna
  TPE optimization, and walk-forward testing of trading strategies.
  - **AlphaForge** (commercial, free trial) → **Commercial & Proprietary Services** — the
  underlying local-first quant CLI: Optuna TPE optimization, walk-forward validation,
  anti-overfitting guards, and TradingView Pine v6 code generation.

  The two are grouped in one PR since the MCP server wraps the CLI (per the "multiple related
  projects sharing a common theme" guideline). The commercial CLI is placed under **Commercial &
  Proprietary Services** per the contribution policy; the OSS MCP server under **Trading &
  Backtesting**. Both descriptions are single-sentence and period-terminated, using `https://`
  links. Thanks for maintaining this list!