### PR TITLE
Add EDGAR Events to Commercial & Proprietary Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [brapi.dev](https://brapi.dev/) - Brazilian stock market data API for B3/Bovespa quotes, historical OHLCV, dividends, and fundamentals.
 - [13F Insight](https://13finsight.com/) - Track institutional investor 13F holdings with AI-powered analysis, position change alerts, and filing summaries.
 - [Earnings Feed](https://earningsfeed.com/api) - Real-time SEC filings, insider trades, and institutional holdings API.
+- [EDGAR Events](https://edgarevents.com) - SEC filing events as typed JSON: 8-K item codes with materiality flags, SC 13D/13G activist stakes (holder, target, percent of class), merger forms, and S-1/424B IPO filings, polled over REST or pushed via HMAC-signed webhooks, sourced from data.sec.gov.
 - [Financial Data](https://financialdata.net/) - Stock Market and Financial Data API.
 - [Frostbyte](https://agent-gateway-kappa.vercel.app) - Real-time crypto prices for 500+ tokens via REST API with free tier, DeFi swap routing and portfolio tracking.
 - [SaxoOpenAPI](https://www.developer.saxo/) - Saxo Bank financial data API.

--- a/README.md
+++ b/README.md
@@ -618,7 +618,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [brapi.dev](https://brapi.dev/) - Brazilian stock market data API for B3/Bovespa quotes, historical OHLCV, dividends, and fundamentals.
 - [13F Insight](https://13finsight.com/) - Track institutional investor 13F holdings with AI-powered analysis, position change alerts, and filing summaries.
 - [Earnings Feed](https://earningsfeed.com/api) - Real-time SEC filings, insider trades, and institutional holdings API.
-- [EDGAR Events](https://edgarevents.com) - SEC filing events as typed JSON: 8-K item codes with materiality flags, SC 13D/13G activist stakes (holder, target, percent of class), merger forms, and S-1/424B IPO filings, polled over REST or pushed via HMAC-signed webhooks, sourced from data.sec.gov.
+- [EDGAR Events](https://edgarevents.com) - `REST` - SEC filing events as typed JSON: 8-K item codes with materiality flags, SC 13D/13G activist stakes (holder, target, percent of class), merger forms, and S-1/424B IPO filings, polled over REST or pushed via HMAC-signed webhooks, sourced from data.sec.gov.
 - [Financial Data](https://financialdata.net/) - Stock Market and Financial Data API.
 - [Frostbyte](https://agent-gateway-kappa.vercel.app) - Real-time crypto prices for 500+ tokens via REST API with free tier, DeFi swap routing and portfolio tracking.
 - [SaxoOpenAPI](https://www.developer.saxo/) - Saxo Bank financial data API.


### PR DESCRIPTION
Adds EDGAR Events under Commercial & Proprietary Services.

EDGAR Events is a paid SEC EDGAR API that returns filing events as typed JSON: 8-K item codes (with a materiality flag), SC 13D/13G activist stakes, merger forms, and S-1/424B IPO filings. You poll the REST API or register an HMAC-signed webhook; data comes from data.sec.gov.

The first link is a commercial website with no public GitHub repo, so per the placement rule it belongs in Commercial & Proprietary Services. One project, format matches the section, and I checked the README plus open and closed PRs for duplicates (none).