### PR TITLE
Add QuantDojo Tools Hub & QuantCheck to awesome-quant

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [VARRD](https://github.com/augiemazza/varrd) - `Python` - AI-powered trading edge discovery platform that validates trading ideas with event studies, statistical tests, and real market data. Web app, MCP server, CLI (`pip install varrd`), and Python SDK.
 - [JIT-Optimization-Engine](https://github.com/cloudsealed/JIT-Optimization-Engine) - `Python` - High-performance analytical core using LLVM JIT (Numba) to process large-scale telemetry for quant diagnostics.
 - [backtester-mcp](https://pypi.org/project/backtester-mcp/) - `Python` - Local-first backtesting engine with built-in overfitting checks (PBO, deflated Sharpe, bootstrap CI, walk-forward) and a native MCP server for AI agents. [GitHub](https://github.com/bcosm/backtester-mcp)
+- [QuantCheck](https://quanttrader-quantcheck.hf.space) - Free no-code backtest validation tool by QuantDojo. Flags overfitting using multiple-testing correction and Deflated Sharpe Ratio. No signup required.
 - [backtest](https://cran.r-project.org/web/packages/backtest/index.html) - `R` - Exploring Portfolio-Based Conjectures About Financial Instruments.
 - [pa](https://cran.r-project.org/web/packages/pa/index.html) - `R` - Performance Attribution for Equity Portfolios.
 - [QuantTools](https://quanttools.bitbucket.io/_site/index.html) - `R` - Enhanced Quantitative Trading Modelling.


### PR DESCRIPTION
## Proposed additions to awesome-quant

### What this PR adds

Two free, no-signup, browser-native tools for quants:

**1. New subsection: `Web-Based Calculators & Validators`** (suggest placing under *Trading & Backtesting*)

```markdown
### Web-Based Calculators & Validators
- [QuantDojo Tools Hub](https://quantdojo.ai/tools/) - Free browser-based calculators: position sizing, Kelly criterion, Sharpe ratio, drawdown recovery, risk/reward & break-even win rate, and trading expectancy. No signup required.
```

**2. Addition to `Backtesting` section**

```markdown
- [QuantCheck](https://quanttrader-quantcheck.hf.space) - Free no-code backtest validation tool by QuantDojo. Flags overfitting using multiple-testing correction and Deflated Sharpe Ratio. No signup required.
```

### Why these fit
- Both are genuinely free and require zero installation or account creation — immediately useful to anyone reading this list.
- QuantCheck addresses a real gap: most backtest tools *run* strategies; this one stress-tests whether an apparent edge is real or overfit noise.
- The calculators cover core quant workflows not currently represented as interactive web tools in the list.

— Wolfgang Lämmle, QuantDojo (quantdojo.ai)