### PR TITLE
Add Clear Street API to Commercial & Proprietary Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Sharpe](https://www.sharpe.ai/) - AI-driven crypto trading intelligence terminal for derivatives positioning, DEX flow, on-chain risk, narrative rotation, token discovery, and agent-ready market data.
 - [Webb Database](https://webb-database.com/) - Aggregates public financial data from HKEX, the SFC, the Hong Law Society, UK Companies House and other sources, has searchable datasets on listed companies, many in machine-readable formats.
 - [GitDealFlow](https://gitdealflow.com) - Alternative-data signal platform ranking early-stage private companies by GitHub stars-per-day, hiring velocity, and package-registry adoption. Free weekly signal report, Chrome extension overlay on Crunchbase/AngelList, and MCP server on npm for LLM agent access.
+- [Clear Street API](https://docs.clearstreet.com/?utm_source=github&utm_medium=developer&utm_campaign=api_listings&utm_content=awesome_quant) - REST API for US equities & options: reference & fundamental data, multi-year financial statements, corporate events, analyst consensus, a screener, and order execution.
 
 ## Related Lists
 


### PR DESCRIPTION
Adds **Clear Street API** to the *Commercial & Proprietary Services* section.

Clear Street is a US self-clearing broker-dealer. Its public REST API exposes US equities & options reference and fundamental data, multi-year financial statements, corporate events, analyst consensus, a screener, and order execution. Public developer docs: https://docs.clearstreet.com/

Checklist (per CONTRIBUTING.md):
- [x] `https://` URL
- [x] One-sentence description ending with a period
- [x] Placed in *Commercial & Proprietary Services* (no language tag, matching that section's existing entries)
- [x] Documented via a public developer portal
- [x] Active / actively maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)
