### PR TITLE
Add VerumTrade to Trading & Backtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [TradeClaw](https://github.com/naimkatiman/tradeclaw) - `Node.js` `TypeScript` - Open-source self-hosted AI trading signal platform. Generates buy/sell signals using RSI, MACD, EMA, Bollinger Bands for forex, crypto and commodities. Deployable via Docker Compose. ([Demo](https://tradeclaw.win/dashboard))
 - [ShowMe](https://github.com/nazmiefearmutcu/showMe) - `Python` `Rust` `TypeScript` - Open-source native macOS market cockpit. 12-timeframe consensus scan across 3370 symbols (crypto + equity + ETF + FX + commodity + bond), 23 technical indicators with per-market calibration, real WebSocket streaming. Tauri shell + Python sidecar (FastAPI) + React UI; 110+ exchanges via ccxt.
 - [TBV1](https://github.com/nazmiefearmutcu/TRADING-BOT) - `Python` - Crypto perpetual-futures bot with a 7-tab web dashboard and a 15-indicator consensus engine voting across 12 timeframes (1m → 1d). Paper-mode by default. Includes packaged macOS reference build and Windows distribution.
+- [VerumTrade](https://github.com/muye1202/VerumTrade) - `Python` - A reasoning & decision-trace visible Multi-agent LLM trading-research framework where bull/bear analysts debate each ticker and every decision cites the evidence it rests on.
 
 ## Portfolio Optimization & Risk Analysis
 


### PR DESCRIPTION
Adds VerumTrade, an open-source (Apache-2.0) multi-agent LLM framework for
trading research and decision support. Bull/bear analyst agents debate each
ticker, a risk manager signs off, **and every decision is required to cite the
evidence IDs it rests on — producing auditable, evidence-linked trade theses
rather than an opaque buy/sell signal.**

Placed under Trading & Backtesting (Python) as the closest existing category;
happy to move it if you'd prefer a different section.

Checklist:
- [x] Single project in this PR
- [x] Format: `- [name](url) - `Language` - description.` ending in a period
- [x] `https://` URL
- [x] Active (commits within the last 12 months)
- [x] README with usage examples (Quick Start for web app, CLI, and Python API)
- [x] Not a duplicate