### PR TITLE
Add Market Posture Daily

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Finterm](https://finterm.xyz) - `TypeScript` - Browser-based, keyboard-first financial terminal. No public GitHub repo (closed source).
 - [Coinugget](https://coinugget.com) - Real-time RSI signals, price action, and volume spikes dashboard across multiple exchanges. Free, no sign-up required.
 - [The Stall](https://the-stall.intuitek.ai) - `JavaScript` - 277 pay-per-call tools via MCP: US stocks, crypto, DeFi analytics, Polymarket prediction markets, macro data, and sanctions screening. USDC on Base. No API key required. [GitHub](https://github.com/thebrierfox/the-stall)
+- [Market Posture Daily](https://marketpd.com) - Daily trend, regime, momentum and relative-strength data for ~90 crypto assets and US stocks/ETFs, with a cointegration pair screener. Free terminal + JSON API.
 
 ## Related Lists
 


### PR DESCRIPTION
Adds Market Posture Daily — a daily-recomputed market dataset (trend, regime,
momentum, relative strength, correlation, and a cointegration pair screener) for
~90 crypto assets and US stocks/ETFs. Free terminal + free JSON API samples.

Placed under Commercial & Proprietary Services since the link is a hosted service
with no public repo. Single entry, format matched to the surrounding lines.