### PR TITLE
Add implied-expectations (reverse DCF / expectations investing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [optionlab](https://github.com/rgaveiga/optionlab) - `Python` - A Python library for evaluating option trading strategies.
 - [flashalpha](https://github.com/FlashAlpha-lab/flashalpha-python) - `Python` - Python client for the FlashAlpha options analytics API.
 - [QuantOracle](https://github.com/QuantOracledev/quantoracle) - `Python` - Free quant finance API with 63 deterministic endpoints + 15 free interactive calculators at [quantoracle.dev](https://quantoracle.dev). Options pricing with full Greeks, Monte Carlo, Kelly, VaR, Sharpe, CAGR, crypto liquidation, impermanent loss, plus live crypto volatility/funding data and 24/7 position monitoring with webhook alerts. 1,000 free calls/day, no API key.
+- [implied-expectations](https://github.com/Keenan-ux/implied-expectations) - `Python` - Reverse DCF that solves for the revenue growth, duration, and operating margin a stock price implies, from SEC EDGAR fundamentals.
 - [RQuantLib](https://github.com/eddelbuettel/rquantlib) - `R` - RQuantLib connects GNU R with QuantLib.
 - [quantmod](https://cran.r-project.org/web/packages/quantmod/index.html) - `R` - Quantitative Financial Modelling Framework. [GitHub](https://github.com/joshuaulrich/quantmod)
 - [Rmetrics](https://www.rmetrics.org) - `R` - The premier open source software solution for teaching and training quantitative finance.


### PR DESCRIPTION
Adds implied-expectations, an MIT-licensed Python library + CLI that inverts a stock price into the growth rate, years, and operating margin it implies (Rappaport/Mauboussin expectations investing).

- Category: Financial Instruments & Pricing (valuation/pricing; same family as the existing Intrinsic-Value-Calculator DCF entry, but run in reverse from the market price)
- Fundamentals from SEC EDGAR companyfacts; price is a user input, no quote-API dependency
- On PyPI as `implied-expectations`; CI on every push
- Test suite includes hand-computed closed-form cases, round-trip property tests, and golden tests over frozen NVDA/AAPL filings
- Active (released this week), documented README with a full worked example

Entry follows the single-language format and ends with a period. One project in this PR.