### PR TITLE
Add PortfolioSavvy SEC ownership research tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [bolsai](https://usebolsai.com) - REST API and MCP server for Brazilian stock market data (B3). Covers 350+ stocks, 400+ FIIs with fundamentals (27+ indicators), dividends, historical prices, financials, and macro indicators sourced from B3, CVM, and BCB.
 - [brapi.dev](https://brapi.dev/) - Brazilian stock market data API for B3/Bovespa quotes, historical OHLCV, dividends, and fundamentals.
 - [13F Insight](https://13finsight.com/) - Track institutional investor 13F holdings with AI-powered analysis, position change alerts, and filing summaries.
+- [PortfolioSavvy](https://portfoliosavvy.com/) - Public SEC ownership research web app for exploring 13F portfolios, insider activity, Schedule 13D/G filings, company facts, and latest filing workflows.
 - [Earnings Feed](https://earningsfeed.com/api) - Real-time SEC filings, insider trades, and institutional holdings API.
 - [EDGAR Events](https://edgarevents.com) - `REST` - SEC filing events as typed JSON: 8-K item codes with materiality flags, SC 13D/13G activist stakes (holder, target, percent of class), merger forms, and S-1/424B IPO filings, polled over REST or pushed via HMAC-signed webhooks, sourced from data.sec.gov.
 - [Financial Data](https://financialdata.net/) - Stock Market and Financial Data API.


### PR DESCRIPTION
Add PortfolioSavvy to Commercial & Proprietary Services as a public SEC ownership research web app.

I placed it in this section because the product URL is a commercial/proprietary website without a linked open-source repository, matching the contributing guide's placement rule.

The entry is factual and focused on SEC ownership workflows: 13F portfolios, insider activity, Schedule 13D/G filings, company facts, and latest filing research.