### PR TITLE
Add tw-stock-radar — Taiwan full-market stock scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [pinkfish](https://github.com/fja05680/pinkfish) - `Python` - A backtester and spreadsheet library for security analysis.
 - [PRISM-INSIGHT](https://github.com/dragon1086/prism-insight) - `Python` - AI-powered stock analysis system with 13 specialized agents, automated trading via KIS API, supporting Korean & US markets.
 - [FinClaw](https://github.com/NeuZhou/finclaw) - `Python` - AI-powered financial intelligence engine with 8 master strategies across US, CN, and HK markets. Multi-agent architecture with +29.1% annual alpha. 227 tests.
+- [tw-stock-radar](https://github.com/carsonchou/tw-stock-radar) - `Python` - AI-powered Taiwan stock scanner for all 1,800+ TWSE/TPEX listed stocks; chips module (T86 institutional net buy/sell + TDCC 16-tier retail distribution), 13 technical indicators scored 0–100, ATR Chandelier signals with TP1/TP2, and a dark FastAPI + three.js HUD dashboard. 100% free open data, ~100 unit tests.
 - [aat](https://github.com/timkpaine/aat) - `Python` - Async Algorithmic Trading Engine.
 - [Backtesting.py](https://kernc.github.io/backtesting.py/) - `Python` - Backtest trading strategies in Python.
 - [catalyst](https://github.com/enigmampc/catalyst) - `Python` - An Algorithmic Trading Library for Crypto-Assets in Python.

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [pinkfish](https://github.com/fja05680/pinkfish) - `Python` - A backtester and spreadsheet library for security analysis.
 - [PRISM-INSIGHT](https://github.com/dragon1086/prism-insight) - `Python` - AI-powered stock analysis system with 13 specialized agents, automated trading via KIS API, supporting Korean & US markets.
 - [FinClaw](https://github.com/NeuZhou/finclaw) - `Python` - AI-powered financial intelligence engine with 8 master strategies across US, CN, and HK markets. Multi-agent architecture with +29.1% annual alpha. 227 tests.
-- [tw-stock-radar](https://github.com/carsonchou/tw-stock-radar) - `Python` - AI-powered Taiwan stock scanner for all 1,800+ TWSE/TPEX listed stocks; chips module (T86 institutional net buy/sell + TDCC 16-tier retail distribution), 13 technical indicators scored 0–100, ATR Chandelier signals with TP1/TP2, and a dark FastAPI + three.js HUD dashboard. 100% free open data, ~100 unit tests.
+- [tw-stock-radar](https://github.com/carsonchou/tw-stock-radar) - `Python` - AI-powered Taiwan stock scanner for all 1,900+ TWSE/TPEX listed stocks; chips module (T86 institutional net buy/sell + TDCC 16-tier retail distribution), 13 technical indicators scored 0–100, ATR Chandelier signals with TP1/TP2, dark three.js HUD dashboard. 100% free open data, ~110 unit tests, no API key required.
 - [aat](https://github.com/timkpaine/aat) - `Python` - Async Algorithmic Trading Engine.
 - [Backtesting.py](https://kernc.github.io/backtesting.py/) - `Python` - Backtest trading strategies in Python.
 - [catalyst](https://github.com/enigmampc/catalyst) - `Python` - An Algorithmic Trading Library for Crypto-Assets in Python.


### PR DESCRIPTION
## Summary

Adding [tw-stock-radar](https://github.com/carsonchou/tw-stock-radar), a free open-source Taiwan stock market scanner.

**What it does:**
- Scans all 1,800+ TWSE + TPEX listed stocks daily
- Chips module: T86 institutional net buy/sell + TDCC 16-tier retail shareholding distribution (free open data)
- 13 technical indicators per stock, scored 0–100 across 4 dimensions (trend/position/momentum/volatility)
- ATR Chandelier stop-loss signals with TP1 (+1.5R) and TP2 (+4.5R)
- Dark FastAPI + three.js HUD dashboard

**Quality:**
- ~100 unit tests (stdlib unittest, zero network calls)
- MIT license
- Used daily in production

Fits the list's existing Asian market entries (alongside Korean/Chinese market tools).