### PR TITLE
Add AlphaAI (financial news API + MCP) to Sentiment Analysis & Alternative Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Social Stock Sentiment API](https://api.adanos.org/docs) - `Python` - REST API analyzing Reddit and X/Twitter for stock mentions and sentiment, providing buzz scores, trending stocks, and AI-generated trend explanations.
 - [CoWorker Fin-Agent](https://github.com/ZiwayZhao/agent-coworker) - `Python` - LLM-powered A-share stock analysis via P2P agent collaboration. Technical analysis (MA60, volume-price patterns, golden eye), deep research reports using proprietary methodology, and market state summaries. Analysis logic stays private via Skill-as-API protocol.
 - [StockKit](https://stockkit.net/) - `TypeScript` - Free AI-powered stock research reports for US, China & HK using Claude Opus and multi-model AI with 20+ technical indicators. [GitHub](https://github.com/kentmswood-ui/stockkit)
+- [AlphaAI](https://alphai.io/developers) - `Python` - Pre-analyzed financial news via REST API and MCP for AI agents: per-ticker impact and sentiment, a category, and a 1-10 relevance score on every story, plus structured SEC Form 4 insider data. Free tier, no card. [GitHub](https://github.com/makeev/alphai-mcp)
 
 ## Time Series Analysis
 


### PR DESCRIPTION
Adds **AlphaAI** to *Sentiment Analysis & Alternative Data*.

AlphaAI turns the financial-news firehose (GDELT + SEC EDGAR + publisher RSS) into machine-readable signal: every story gets per-ticker impact analysis and sentiment, a category, and a 1–10 relevance score, plus structured SEC Form 4 insider data. Consumable as a REST API or an MCP server, with a real free tier (no card).

- Site / live playground: https://alphai.io/developers
- OpenAPI 3.1: https://api.alphai.io/api/schema/
- MCP showcase repo: https://github.com/makeev/alphai-mcp

The entry follows the section's format (name, language tag, one-line description, GitHub link) and sits alongside the other news/sentiment API services already listed.