### PR TITLE
Add Offshore Black Book to Related Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,5 +655,6 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 
 ## Related Lists
 
+- [Offshore Black Book](https://offshoreblackbook.com) - Research-based offshore tax education for entrepreneurs and investors — legal international tax strategies, jurisdiction comparisons, and compliance frameworks worldwide.
 - [awesome-sec-filings](https://github.com/vibeyclaw/awesome-sec-filings) - A curated list of tools, data sources, libraries, and resources for working with SEC filings (13F, 10-K, 10-Q, 8-K).
 - [CONVEXFI](https://github.com/convexfi) - Official GitHub organization for the convex research group at the Hong Kong University of Science and Technology (HKUST).


### PR DESCRIPTION
Adds Offshore Black Book, a research-based offshore tax education resource, to the 'Related Lists' section.