### PR TITLE
Add free Polymarket/Kalshi matched-book dataset (Prediction Markets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [pmxt](https://github.com/pmxt-dev/pmxt) - `Python` `JavaScript` - The CCXT for prediction markets. A unified API for trading on Polymarket, Kalshi, and more.
 - [PolyMind](https://polyminds.netlify.app/) - `Python` - Real-time Polymarket trading alerts with multi-AI analysis (Groq, Claude, Gemini). Track whale bets, volume spikes, coordinated wallets, and 12 signal types. Free tier available. [GitHub](https://github.com/samirasadov28-code/PolyMind)
 - [prediction-market-maker](https://github.com/octavi42/prediction-market-maker) - `Python` - Open-source market-making strategy that placed #2 in Paradigm's prediction market challenge, with full strategy evolution and analysis.
+- - [Polymarket × Kalshi Matched Book](https://huggingface.co/datasets/Coyevans/mlb-polymarket-kalshi-matched-book-sample) - Free historical sample dataset: Polymarket and Kalshi orderbook prices aligned in the same window with Kalshi settled-outcome labels on every row, downloadable as Parquet/CSV with a Zenodo DOI for citation.
 - [Oracle3](https://github.com/YichengYang-Ethan/oracle3) - `Python` - Autonomous trading agent for Kalshi, Polymarket, and Solana — Wang Transform pricing (calibrated on 291k resolved contracts) drives eight constraint-based arbitrage strategies and Kelly-sized model trades.
 
 ## Calendars & Market Hours

--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [pmxt](https://github.com/pmxt-dev/pmxt) - `Python` `JavaScript` - The CCXT for prediction markets. A unified API for trading on Polymarket, Kalshi, and more.
 - [PolyMind](https://polyminds.netlify.app/) - `Python` - Real-time Polymarket trading alerts with multi-AI analysis (Groq, Claude, Gemini). Track whale bets, volume spikes, coordinated wallets, and 12 signal types. Free tier available. [GitHub](https://github.com/samirasadov28-code/PolyMind)
 - [prediction-market-maker](https://github.com/octavi42/prediction-market-maker) - `Python` - Open-source market-making strategy that placed #2 in Paradigm's prediction market challenge, with full strategy evolution and analysis.
-- - [Polymarket × Kalshi Matched Book](https://huggingface.co/datasets/Coyevans/mlb-polymarket-kalshi-matched-book-sample) - Free historical sample dataset: Polymarket and Kalshi orderbook prices aligned in the same window with Kalshi settled-outcome labels on every row, downloadable as Parquet/CSV with a Zenodo DOI for citation.
+- [Polymarket × Kalshi Matched Book](https://huggingface.co/datasets/Coyevans/mlb-polymarket-kalshi-matched-book-sample) - Free historical sample dataset: Polymarket and Kalshi orderbook prices aligned in the same window with Kalshi settled-outcome labels on every row, downloadable as Parquet/CSV with a Zenodo DOI for citation.
 - [Oracle3](https://github.com/YichengYang-Ethan/oracle3) - `Python` - Autonomous trading agent for Kalshi, Polymarket, and Solana — Wang Transform pricing (calibrated on 291k resolved contracts) drives eight constraint-based arbitrage strategies and Kelly-sized model trades.
 
 ## Calendars & Market Hours

--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [pmxt](https://github.com/pmxt-dev/pmxt) - `Python` `JavaScript` - The CCXT for prediction markets. A unified API for trading on Polymarket, Kalshi, and more.
 - [PolyMind](https://polyminds.netlify.app/) - `Python` - Real-time Polymarket trading alerts with multi-AI analysis (Groq, Claude, Gemini). Track whale bets, volume spikes, coordinated wallets, and 12 signal types. Free tier available. [GitHub](https://github.com/samirasadov28-code/PolyMind)
 - [prediction-market-maker](https://github.com/octavi42/prediction-market-maker) - `Python` - Open-source market-making strategy that placed #2 in Paradigm's prediction market challenge, with full strategy evolution and analysis.
-- [Polymarket × Kalshi Matched Book](https://huggingface.co/datasets/Coyevans/mlb-polymarket-kalshi-matched-book-sample) - Free historical sample dataset: Polymarket and Kalshi orderbook prices aligned in the same window with Kalshi settled-outcome labels on every row, downloadable as Parquet/CSV with a Zenodo DOI for citation.
+- [Polymarket × Kalshi Matched Book](https://huggingface.co/datasets/Coyevans/mlb-polymarket-kalshi-matched-book-sample) - `Data` - Free historical sample dataset: Polymarket and Kalshi orderbook prices aligned in the same window with Kalshi settled-outcome labels on every row, downloadable as Parquet/CSV with a Zenodo DOI for citation.
 - [Oracle3](https://github.com/YichengYang-Ethan/oracle3) - `Python` - Autonomous trading agent for Kalshi, Polymarket, and Solana — Wang Transform pricing (calibrated on 291k resolved contracts) drives eight constraint-based arbitrage strategies and Kelly-sized model trades.
 
 ## Calendars & Market Hours


### PR DESCRIPTION
Adds a free, openly licensed (CC BY-NC) downloadable dataset — Polymarket and Kalshi prices for a full MLB game aligned on one timeline with settled outcomes labeled. HF-hosted with a Zenodo DOI. Research/backtest data, not a trading signal.