### PR TITLE
Add Korea Stock Data (KOSPI/KOSDAQ dataset)

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [TimeFrames.jl](https://github.com/femtotrader/TimeFrames.jl) - `Julia` - A Julia library that defines TimeFrame (essentially for resampling TimeSeries).
 
 ## Market Data & Data Sources
+- [Korea Stock Data](https://github.com/na77tech-creator/korea-stock-data) - `Data` - Free daily dataset of top KOSPI/KOSDAQ stocks by market cap: prices, fundamentals, and analyst consensus estimates in CSV/JSON, updated every trading day, LLM/AI-readable.
 - [BTC Orderbook Microstructure Research](https://github.com/whoareunot/btc-orderbook-research) - `Jupyter Notebook` - statistical analysis of Binance BTC/USDT orderbook: OBI, CVD, spread.  
 - [OpenBB Terminal](https://github.com/OpenBB-finance/OpenBBTerminal) - `Python` - Terminal for investment research for everyone.
 - [Fincept Terminal](https://github.com/Fincept-Corporation/FinceptTerminal) - `Python` - Advance Data Based A.I Terminal for all Types of Financial Asset Research.


### PR DESCRIPTION
Adds a free, open daily dataset of top KOSPI/KOSDAQ stocks by market cap (prices, fundamentals, analyst consensus) in CSV/JSON. The list currently has no Korean market data source, so this fills a regional gap. Updated every trading day via GitHub Actions; self-describing JSON + llms.txt for LLM/AI use.