### PR TITLE
Add AlphaAssay to Commercial & Proprietary Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Finterm](https://finterm.xyz) - `TypeScript` - Browser-based, keyboard-first financial terminal. No public GitHub repo (closed source).
 - [Coinugget](https://coinugget.com) - Real-time RSI signals, price action, and volume spikes dashboard across multiple exchanges. Free, no sign-up required.
 - [The Stall](https://the-stall.intuitek.ai) - `JavaScript` - 277 pay-per-call tools via MCP: US stocks, crypto, DeFi analytics, Polymarket prediction markets, macro data, and sanctions screening. USDC on Base. No API key required. [GitHub](https://github.com/thebrierfox/the-stall)
+- [AlphaAssay](https://alphaassay.com) - `REST` - Independent statistical assay office for trading signals and backtests: deflated Sharpe with cumulative trial accounting, probability of backtest overfitting (PBO/CPCV), leakage forensics, placebo tests against matched synthetic null worlds, and pre-registration with Merkle-anchored timestamps — deterministic, Ed25519-signed verdicts anyone can replay. Free demo; hosted API and MCP server. Methodology audit, not investment advice. [GitHub](https://github.com/alphaassay/mcp)
 
 ## Related Lists
 


### PR DESCRIPTION
Adds AlphaAssay to Commercial & Proprietary Services — an independent statistical assay office for trading signals and backtests: deflated Sharpe with cumulative trial accounting, PBO/CPCV overfitting checks, leakage forensics, placebo tests against matched synthetic null worlds, and pre-registration with Merkle-anchored timestamps. Hosted REST API and MCP server; free deterministic demo with golden test vectors. Methodology audit, not investment advice.

Entry uses the website+GitHub format from CONTRIBUTING.md and is added at the bottom of the section.