### PR TITLE
Add Backtesting Arena to Market Data & Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [fin-stream](https://github.com/Mattbusel/fin-stream) - `Rust` - Real-time market data streaming in Rust: lock-free SPSC ring buffer, 100K+ ticks/second ingestion, multi-timeframe OHLCV construction, and Lorentz transforms on financial time series.
 - [finalytics](https://github.com/Nnamdi-sys/finalytics) - `Rust` - A rust library for financial data analysis.
 - [Factor Weave](https://factorweave.com/) - `Python` `TypeScript` `R` - Factor scores, similarity search, and leak-free + survivor-free forward-return labels across equities, ETFs, indices, FX, crypto, and futures; REST + MCP, Python/TypeScript/R SDKs, free tier. [GitHub](https://github.com/Blazing-Customs/factorweave-tools)
+- [Backtesting Arena](https://tradingstrategies.work/api) - `TypeScript` - REST + MCP API for point-in-time Bitcoin cycle scoring, 22 on-chain series since 2009 (MVRV, NUPL, SOPR, Mayer, Puell), macro-regime composites and look-ahead-aware backtest validation with Deflated-Sharpe-Ratio correction across crypto, stocks, ETFs, commodities and forex. Free tier. [GitHub](https://github.com/Schoasch/skill-backtesting-arena)
 
 
 ## Prediction Markets


### PR DESCRIPTION
Adds **Backtesting Arena** to the **Market Data & Data Sources** section.

REST + MCP API for point-in-time Bitcoin cycle scoring, 22 on-chain series since 2009 (MVRV, NUPL, SOPR, Mayer, Puell), macro-regime composites and look-ahead-aware backtest validation with Deflated-Sharpe-Ratio / multiple-testing correction, across crypto, stocks, ETFs, commodities and forex. Free tier.

Follows the entry format (`[Name](link) - \`TypeScript\` - description. [GitHub]`), consistent with existing hosted REST/MCP data sources such as Factor Weave, Helium MCP and financekit-mcp. Home: https://tradingstrategies.work/api · Repo: https://github.com/Schoasch/skill-backtesting-arena

🤖 Generated with [Claude Code](https://claude.com/claude-code)