### PR TITLE
Add NeuPortal to Commercial & Proprietary Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Finterm](https://finterm.xyz) - `TypeScript` - Browser-based, keyboard-first financial terminal. No public GitHub repo (closed source).
 - [Coinugget](https://coinugget.com) - Real-time RSI signals, price action, and volume spikes dashboard across multiple exchanges. Free, no sign-up required.
 - [The Stall](https://the-stall.intuitek.ai) - `JavaScript` - 277 pay-per-call tools via MCP: US stocks, crypto, DeFi analytics, Polymarket prediction markets, macro data, and sanctions screening. USDC on Base. No API key required. [GitHub](https://github.com/thebrierfox/the-stall)
+- [NeuPortal](https://neuportal.ai) - AI forecasting-accountability lab: every forecast is locked pre-event, Bitcoin-timestamped (OpenTimestamps), and Brier-scored against prediction markets in public.
 
 ## Related Lists
 


### PR DESCRIPTION
Adds **NeuPortal** to the **Commercial & Proprietary Services** section.

Per CONTRIBUTING, the main URL is a commercial website with no open-source GitHub repo, so it belongs in Commercial & Proprietary Services (not the thematic Prediction Markets section).

NeuPortal is an AI forecasting-accountability lab: every forecast is locked pre-event, Bitcoin-timestamped (OpenTimestamps), and Brier-scored against prediction markets in public.

- Site: https://neuportal.ai

Entry format matches the section's existing pattern (commercial service, no language tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)