### PR TITLE
Add TypeScript US market-data clients and market calendars

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,10 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [OpenBB Terminal](https://github.com/OpenBB-finance/OpenBBTerminal) - `Python` - Terminal for investment research for everyone.
 - [Fincept Terminal](https://github.com/Fincept-Corporation/FinceptTerminal) - `Python` - Advance Data Based A.I Terminal for all Types of Financial Asset Research.
 - [yfinance](https://github.com/ranaroussi/yfinance) - `Python` - Yahoo! Finance market data downloader (+faster Pandas Datareader).
+- [treasurydirect](https://github.com/moshejs/treasurydirect) - `TypeScript` - Zero-dependency client for the US TreasuryDirect API: auction results, upcoming auctions, CUSIP lookups, and Debt to the Penny; no API key required.
+- [treasury-fiscaldata](https://github.com/moshejs/treasury-fiscaldata) - `TypeScript` - Typed client for the US Treasury FiscalData API (debt, average interest rates, exchange rates) with pagination and filtering; no API key required.
+- [newyorkfed](https://github.com/moshejs/newyorkfed) - `TypeScript` - Client for the NY Fed Markets Data API: SOFR/EFFR/OBFR reference rates, SOFR averages and index, and SOMA holdings; no API key required.
+- [commitments-of-traders](https://github.com/moshejs/commitments-of-traders) - `TypeScript` - Client for the CFTC Commitments of Traders reports (Legacy, Disaggregated, TFF; futures-only and combined) via the official Socrata API.
 - [coinpaprika-api-python-client](https://github.com/coinpaprika/coinpaprika-api-python-client) - `Python` - Free crypto market data API client. 12,000+ coins, 350+ exchanges, tickers, OHLCV, historical prices. No API key for free tier.
 - [defeatbeta-api](https://github.com/defeat-beta/defeatbeta-api) - `Python` - An open-source alternative to Yahoo Finance's market data APIs with higher reliability.
 - [financekit-mcp](https://github.com/vdalhambra/financekit-mcp) - `Python` - MCP server (Model Context Protocol) exposing 17 tools for AI agents to perform quantitative analysis: real-time stock quotes, full technical analysis (RSI, MACD, Bollinger, ADX, Stochastic, ATR, OBV + pattern detection with structured verdicts), crypto prices via CoinGecko, risk metrics (VaR, Sharpe, Sortino, Beta, Max Drawdown), correlation matrix, options chains, earnings calendar, sector rotation, and portfolio analysis. Works with Claude Desktop, Cursor, Windsurf. No API keys for core tools. FastMCP 3.2.
@@ -507,6 +511,9 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [pandas_market_calendars](https://github.com/rsheftel/pandas_market_calendars) - `Python` - Exchange calendars to use with pandas for trading applications.
 - [timeDate](https://cran.r-project.org/web/packages/timeDate/index.html) - `R` - Chronological and Calendar Objects.
 - [bizdays](https://github.com/wilsonfreitas/R-bizdays) - `R` - Business days calculations and utilities.
+- [sifma-holidays](https://github.com/moshejs/sifma-holidays) - `TypeScript` - US bond-market (SIFMA) holidays, early closes, and T+1 settlement-date math; zero dependencies.
+- [us-equity-market-calendar](https://github.com/moshejs/us-equity-market-calendar) - `TypeScript` - NYSE/NASDAQ trading calendar: holidays, 1pm early closes, trading-day navigation, and DST-aware is-market-open; zero dependencies.
+- [fx-value-date](https://github.com/moshejs/fx-value-date) - `TypeScript` - FX spot/forward value-date calculation across two currency holiday calendars, with the USD-lag and end-of-month rules; zero dependencies.
 
 ## Visualization
 


### PR DESCRIPTION
Adds complementary data-infrastructure libraries from the same author (me), batched per the CONTRIBUTING note on multiple data sources for the same market:

**Market Data & Data Sources** — typed, zero-dependency clients for free US government market-data APIs (all keyless):
- **treasurydirect** — Treasury auctions, CUSIP lookups, Debt to the Penny
- **treasury-fiscaldata** — Treasury FiscalData (debt, avg interest rates, FX rates)
- **newyorkfed** — NY Fed reference rates (SOFR/EFFR), SOFR averages & index, SOMA
- **commitments-of-traders** — CFTC COT reports (the section currently lists no open-source COT client; existing Fed/Treasury clients are Python-only)

**Calendars & Market Hours** — the section's first JS/TS entries, and its first bond-market and FX-settlement calendars:
- **sifma-holidays** — the US bond-market calendar (differs from equities: Columbus/Veterans Day closes, 2pm early closes) + T+1 settlement
- **us-equity-market-calendar** — NYSE/NASDAQ sessions verified against the published 2025–2028 schedules
- **fx-value-date** — FX value dates across two currency calendars

All MIT, active (July 2026), documented, mocked test suites plus live smoke tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)