### PR TITLE
Add REAMER to Commercial & Proprietary Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Finterm](https://finterm.xyz) - `TypeScript` - Browser-based, keyboard-first financial terminal. No public GitHub repo (closed source).
 - [Coinugget](https://coinugget.com) - Real-time RSI signals, price action, and volume spikes dashboard across multiple exchanges. Free, no sign-up required.
 - [The Stall](https://the-stall.intuitek.ai) - `JavaScript` - 277 pay-per-call tools via MCP: US stocks, crypto, DeFi analytics, Polymarket prediction markets, macro data, and sanctions screening. USDC on Base. No API key required. [GitHub](https://github.com/thebrierfox/the-stall)
+- [REAMER](https://reamerlabs.com) - Local-first, deterministic backtesting and research engine for systematic OHLCV trading, with execution modeled to a published specification and verified by a conformance suite.
 
 ## Related Lists
 


### PR DESCRIPTION
REAMER is a local-first backtesting and research engine for systematic OHLCV trading (forex/CFD, futures, equities). Python strategy SDK on a C++ execution core, with fills modeled to a published, testable execution specification (https://reamerlabs.com/spec) rather than an unspecified black box, verified by a 282-check conformance suite. Deterministic seeded execution, tick-level replay, and Monte Carlo robustness testing (bootstrapped equity curves, risk of ruin, drawdown percentiles) are built in. It is research-only -- validated strategy logic is the finished output, with deployment (a broker, an OMS, or otherwise) left to separate tools downstream. The GUI is free with no license required; reamer_py is free up to a 10,000-bar-per-machine processing cap.

Added to Commercial & Proprietary Services since it does not currently have a public GitHub repository link included -- happy to have it moved to a more fitting section (e.g. Trading & Backtesting) in the future once one is available.