### PR TITLE
Fix Reddit WallstreetBets API link (domain moved to tradestie.com)

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Nasdaq Data Link](https://data.nasdaq.com/tools/full-list) - Financial data API with support for R, Python, Excel, Ruby, and many other languages (formerly Quandl).
 - [Parsec](https://parsecfinance.com) - Prediction market API with Python SDK for normalized data and execution across 5 prediction market exchanges. Free tier: 10K requests/month.
 - [Portfolio Optimizer](https://portfoliooptimizer.io/) - Portfolio Optimizer is a Web API for portfolio analysis and optimization.
-- [Reddit WallstreetBets API](https://dashboard.nbshare.io/apps/reddit/api/) - Provides daily top 50 stocks from reddit (subreddit) Wallstreetbets and their sentiments via the API.
+- [Reddit WallstreetBets API](https://tradestie.com/apps/reddit/api/) - Provides daily top 50 stocks from reddit (subreddit) Wallstreetbets and their sentiments via the API.
 - [System R](https://agents.systemr.ai) - AI-native risk intelligence API for trading agents. Position sizing, risk validation, and system health in one call.
 - [Telonex](https://telonex.io) - Tick-level prediction market data (trades, quotes, orderbooks, on-chain fills) via REST API and Python SDK.
 - [ValueRay](https://www.valueray.com/api) - Technical, quantitative and sentiment data for stocks and ETFs with risk metrics, peer percentiles and market regime signals. Optimized for AI/LLM agents.


### PR DESCRIPTION
The Reddit WallstreetBets API entry links to https://dashboard.nbshare.io/apps/reddit/api/ which now returns 403 (dead link). The API moved to https://tradestie.com/apps/reddit/api/ — same API and maintainer (I run this service). Endpoint: https://tradestie.com/api/v1/apps/reddit (free, no auth).