### PR TITLE
Add AlphaSMO to Market Data & Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [findatapy](https://github.com/cuemacro/findatapy) - `Python` - Python library to download market data via Bloomberg, Quandl, Yahoo etc.
 - [googlefinance](https://github.com/hongtaocai/googlefinance) - `Python` - Python module to get real-time stock data from Google Finance API.
 - [Horus Flow](https://github.com/horustechltd/horus-flow-mcp) - `Python` - Sub-second L2 orderflow intelligence MCP server for institutional-grade market microstructure analysis.
+- [AlphaSMO](https://github.com/alphasmo/alphasmo-tools) - `TypeScript` - CLI + MCP server for SEC 13F institutional holdings, Form 4 insider trading, and smart money convergence signals (tickers where hedge funds and company insiders are both buying). Free anonymous tier, no signup required.
 - [yahoo-finance](https://github.com/lukaszbanasiak/yahoo-finance) - `Python` - Python module to get stock data from Yahoo! Finance.
 - [pandas-datareader](https://github.com/pydata/pandas-datareader) - `Python` - Python module to get data from various sources (Google Finance, Yahoo Finance, FRED, OECD, Fama/French, World Bank, Eurostat...) into Pandas datastructures such as DataFrame, Panel with a caching mechanism.
 - [pandas-finance](https://github.com/davidastephens/pandas-finance) - `Python` - High level API for access to and analysis of financial data.


### PR DESCRIPTION
Adds AlphaSMO: SEC 13F institutional holdings, Form 4 insider trading, and a "smart money convergence" signal (tickers where hedge funds and company insiders are both buying).

Free anonymous tier, no signup required — `npx alphasmo convergence`. MIT licensed, source at https://github.com/alphasmo/alphasmo-tools.

One line added to Market Data & Data Sources, matching the existing entry format.