### PR TITLE
Add StreamXLS (Commercial & Proprietary Services)

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Coinugget](https://coinugget.com) - Real-time RSI signals, price action, and volume spikes dashboard across multiple exchanges. Free, no sign-up required.
 - [The Stall](https://the-stall.intuitek.ai) - `JavaScript` - 277 pay-per-call tools via MCP: US stocks, crypto, DeFi analytics, Polymarket prediction markets, macro data, and sanctions screening. USDC on Base. No API key required. [GitHub](https://github.com/thebrierfox/the-stall)
 - [Market Posture Daily](https://marketpd.com) - Daily trend, regime, momentum and relative-strength data for ~90 crypto assets and US stocks/ETFs, with a cointegration pair screener. Free terminal + JSON API.
+- [StreamXLS](https://streamxls.com) - Commercial Excel RTD server for the Interactive Brokers TWS API, streaming market data, account values, positions, and open orders into Excel formulas on Windows.
 
 ## Related Lists
 


### PR DESCRIPTION
Adds **StreamXLS** to *Commercial & Proprietary Services*.

StreamXLS is a Windows RTD server for the Interactive Brokers TWS API. It streams market data, account values, positions with P&L, and open-order status into Microsoft Excel through native `=RTD()` formulas — no add-in, no VBA, no code. Commercial, 30-day trial.

Placement: the main URL is a commercial site with no source repository as a second link, so per CONTRIBUTING's placement rule it belongs in Commercial & Proprietary Services rather than Excel & Spreadsheet Integration. Happy to be moved if you judge it otherwise — the closest functional neighbour there is PyXLL.

Format check: single entry, one project, HTTPS, one sentence ending in a period, appended to the end of the section (which is not alphabetised). No language tag, matching the majority of entries in this section — the product is used from Excel formulas rather than a programming language.

Disclosure: I'm the developer.