### PR TITLE
Add SEFCON API — Korean stock fundamentals from DART XBRL

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [alpha_vantage](https://github.com/RomelTorres/alpha_vantage) - `Python` - A python wrapper for Alpha Vantage API for financial data.
 - [oilpriceapi](https://github.com/OilpriceAPI/python-sdk) - `Python` - Python SDK for real-time oil and commodity prices (WTI, Brent, Urals, natural gas, coal) with OpenBB integration.
 - [FinanceDataReader](https://github.com/FinanceData/FinanceDataReader) - `Python` - Open Source Financial data reader for U.S, Korean, Japanese, Chinese, Vietnamese Stocks.
+- [SEFCON API](https://api.sefcon.kr) - REST API for Korean stock fundamentals — 1,200+ KOSPI/KOSDAQ companies, 10-year financials parsed directly from DART XBRL. Includes SCI quality scores, sector cycle detection, and macro crisis index (AUROC 0.927).
 - [pystlouisfed](https://github.com/TomasKoutek/pystlouisfed) - `Python` - Python client for Federal Reserve Bank of St. Louis API - FRED, ALFRED, GeoFRED and FRASER.
 - [python-bcb](https://github.com/wilsonfreitas/python-bcb) - `Python` - Python interface to Brazilian Central Bank web services.
 - [swiss-finance-data](https://github.com/EMen11/swiss-finance-data) - `Python` - Python package for Swiss financial data (SNB Policy Rate, SARON, CHF FX rates, CPI, SMI equities, Confederation bond yields) from official SNB sources.


### PR DESCRIPTION
SEFCON API provides Korean stock fundamentals parsed directly from DART XBRL (Korea's official SEC-equivalent regulatory filings) — not resold from FnGuide or KisValue.

- 1,200+ KOSPI/KOSDAQ companies
- 10-year annual financials (EPS, BPS, ROE, OPM, FCF, DPS)
- SCI quality scores & sector cycle detection (19 sectors)
- Macro crisis index (AUROC 0.927)
- Free plan available on RapidAPI

API docs: https://api.sefcon.kr