### PR TITLE
Add polymarket-bot-lab to Prediction Markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [PolyMind](https://polyminds.netlify.app/) - `Python` - Real-time Polymarket trading alerts with multi-AI analysis (Groq, Claude, Gemini). Track whale bets, volume spikes, coordinated wallets, and 12 signal types. Free tier available. [GitHub](https://github.com/samirasadov28-code/PolyMind)
 - [prediction-market-maker](https://github.com/octavi42/prediction-market-maker) - `Python` - Open-source market-making strategy that placed #2 in Paradigm's prediction market challenge, with full strategy evolution and analysis.
 - [Oracle3](https://github.com/YichengYang-Ethan/oracle3) - `Python` - Autonomous trading agent for Kalshi, Polymarket, and Solana — Wang Transform pricing (calibrated on 291k resolved contracts) drives eight constraint-based arbitrage strategies and Kelly-sized model trades.
+- [polymarket-bot-lab](https://github.com/oraclemangle/polymarket-bot-lab) - `Python` - Open-sourced research lab of 11 candidate Polymarket trading bots (weather, sports, longshot fades, maker, whale-flow) with a shared CLOB/backtest framework, ADR decision log, and honest paper/live results. Companion free dataset: [polymarket-canary-tape](https://huggingface.co/datasets/oraclemangle/polymarket-canary-tape) (300M+ events, CC-BY-4.0).
 
 ## Calendars & Market Hours
 


### PR DESCRIPTION
Adds [polymarket-bot-lab](https://github.com/oraclemangle/polymarket-bot-lab): an open-sourced (Apache-2.0) research lab of 11 candidate Polymarket trading bots with a shared CLOB/backtest framework, full ADR decision log, and honest paper/live results, plus a free CC-BY-4.0 companion dataset of 300M+ market events on Hugging Face. Follows the section's entry format; one item.