### PR TITLE
Add vanilla-option-pricers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [pyfin](https://github.com/opendoor-labs/pyfin) - `Python` - Basic options pricing in Python. *ARCHIVED*.
 - [vollib](https://github.com/vollib/vollib) - `Python` - vollib is a python library for calculating option prices, implied volatility and greeks.
 - [py_vollib](https://github.com/vollib/py_vollib) - `Python` - vollib Python implementation.
+- [vanilla-option-pricers](https://github.com/ArturSepp/VanillaOptionPricers) - `Python` - Fast, vectorised Black-Scholes-Merton and Bachelier pricers and implied volatility fitters, including inverse options for crypto derivatives.
 - [StochVolModels](https://github.com/ArturSepp/StochVolModels) - `Python` - Pricing analytics and Monte Carlo simulation for stochastic volatility models, including the log-normal SV model and the Heston model.
 - [QuantPy](https://github.com/jsmidt/QuantPy) - `Python` - A framework for quantitative finance In python.
 - [Finance-Python](https://github.com/alpha-miner/Finance-Python) - `Python` - Python tools for Finance.


### PR DESCRIPTION
Adds **vanilla-option-pricers** to Financial Instruments & Pricing.

Fast Numba-vectorised pricers and implied volatility fitters for Black-Scholes-Merton and Bachelier models, including coin-denominated inverse options as traded on crypto derivatives exchanges. Two runtime dependencies (numpy, numba). On PyPI, MIT licensed, CI in place.

Disclosure: I am the author and maintainer.