### PR TITLE
Add Wealthville to Commercial & Proprietary Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,6 +728,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [AtlasYield](https://atlasyield.club) - Independent rating and allocation layer for on-chain yield: scores every DeFi vault 0-100 across 16 factors, with a public read-only scores API. [GitHub](https://github.com/gveshk/atlasyield-score-history)
 - [Katana](https://katanascreener.com) - Free Japan stock screener built on EDINET filings. 160+ fundamentals, custom formula metrics, Graham/Piotroski/Kiyohara presets. No sign-up.
 - [Disclosed Capitol](https://www.disclosedcapitol.com/data-files/api) - US congressional and executive-branch stock trade disclosures API. STOCK Act filings plus OGE executive data (~6,743 transactions across 106 officials), with trade-level returns and alpha. Free tier: 500 credits, no card.
+- [Wealthville](https://wealthville.net) - `REST` `MCP` - Liquidity-pool scoring for DeFi market making: a 0-100 score and an Enter/Hold/Exit/Reduce/Avoid verdict, with confidence calibrated per protocol, across ~68,800 Solana pools (Meteora DLMM, Orca Whirlpool, Raydium AMM/CLMM/CPMM) and 575 EVM pools on Ethereum, Arbitrum, Base, Optimism, Polygon and BSC. Outcomes are graded after impermanent loss and published as a miss-inclusive 30-day track record. Free keyless API, OpenAPI spec, and a hosted MCP server. [GitHub](https://github.com/amitesh-m/wealthville-integrations)
 
 
 ## Related Lists


### PR DESCRIPTION
Adds one entry to `## Commercial & Proprietary Services`.

**Wealthville** scores DeFi liquidity pools for market-making decisions — a 0-100 score plus an Enter/Hold/Exit/Reduce/Avoid verdict, with confidence calibrated per protocol rather than pooled across all of them.

- **Coverage** — ~68,800 Solana pools (Meteora DLMM, Orca Whirlpool, Raydium AMM/CLMM/CPMM) and 575 EVM pools on Ethereum, Arbitrum, Base, Optimism, Polygon and BSC.
- **Graded after IL** — outcomes are measured net of impermanent loss, not on headline APR.
- **Miss-inclusive track record** — `/api/v1/track-record` publishes hit rates *and* the failures over a rolling 30 days. Current: ENTER 0.63 across 3,043 resolved calls, EXIT 0.69, AVOID 1.00 (n=36), and REDUCE **0.00 on n=16**. That last one is published deliberately; a track record that only shows the wins isn't one.
- **Access** — free keyless REST API (60 req/min anonymous, 600 with a free key), public OpenAPI spec, and a hosted MCP server.

Filed under Commercial & Proprietary because the scoring engine is closed-source; the linked repo is the MIT-licensed connector layer (MCP server, ElizaOS and Solana Agent Kit plugins).

Followed `AGENTS.md`: entry matches the parser regex, tags are in individual backtick pairs, the description ends with a period before the `[GitHub]` suffix, and the URL is `https://`. `uv run python scripts/validate_readme.py --diff-from origin/main` reports **"Validated 1 entries… Validation passed."**

Disclosure: I maintain this project.