### PR TITLE
Add YieldScope to Market Data & Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [PineForge](https://github.com/pineforge-4pass/pineforge-engine) - `C++` - Deterministic offline PineScript v6 → C++ backtest runtime, validated trade-for-trade against TradingView (245/246 strict, 0 engine bugs). Runs locally via Docker and is drivable by AI agents through a bundled MCP server.
 
 ## Market Data & Data Sources
+- [YieldScope](https://yieldscope.io/api/rates.json) - `Data` - Free JSON feed of base (non-promotional) APY rates across 37 CeFi crypto venues and 1,425 coin-venue pairs, each with an A–F safety grade scored on five risk criteria, plus cheapest borrow rates for 21 assets. No API key, CORS enabled, refreshed daily.
 - [Korea Stock Data](https://github.com/na77tech-creator/korea-stock-data) - `Data` - Free daily dataset of top KOSPI/KOSDAQ stocks by market cap: prices, fundamentals, and analyst consensus estimates in CSV/JSON, updated every trading day, LLM/AI-readable.
 - [BTC Orderbook Microstructure Research](https://github.com/whoareunot/btc-orderbook-research) - `Jupyter Notebook` - statistical analysis of Binance BTC/USDT orderbook: OBI, CVD, spread.  
 - [OpenBB Terminal](https://github.com/OpenBB-finance/OpenBBTerminal) - `Python` - Terminal for investment research for everyone.

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [PineForge](https://github.com/pineforge-4pass/pineforge-engine) - `C++` - Deterministic offline PineScript v6 → C++ backtest runtime, validated trade-for-trade against TradingView (245/246 strict, 0 engine bugs). Runs locally via Docker and is drivable by AI agents through a bundled MCP server.
 
 ## Market Data & Data Sources
-- [YieldScope](https://yieldscope.io/api/rates.json) - `Data` - Free JSON feed of base (non-promotional) APY rates across 37 CeFi crypto venues and 1,425 coin-venue pairs, each with an A–F safety grade scored on five risk criteria, plus cheapest borrow rates for 21 assets. No API key, CORS enabled, refreshed daily.
+- [YieldScope](https://yieldscope.io/api/rates.json) - `Data` - Free JSON feed of base (non-promotional) APY rates across 37 crypto venues — CeFi exchanges and liquid-staking protocols — with an A–F safety grade per venue scored on five published risk criteria, plus borrow rates. No API key, CORS enabled, refreshed daily.
 - [Korea Stock Data](https://github.com/na77tech-creator/korea-stock-data) - `Data` - Free daily dataset of top KOSPI/KOSDAQ stocks by market cap: prices, fundamentals, and analyst consensus estimates in CSV/JSON, updated every trading day, LLM/AI-readable.
 - [BTC Orderbook Microstructure Research](https://github.com/whoareunot/btc-orderbook-research) - `Jupyter Notebook` - statistical analysis of Binance BTC/USDT orderbook: OBI, CVD, spread.  
 - [OpenBB Terminal](https://github.com/OpenBB-finance/OpenBBTerminal) - `Python` - Terminal for investment research for everyone.


### PR DESCRIPTION
Adds YieldScope, a free JSON feed of crypto yield rates, to Market Data & Data Sources.

- Endpoint: https://yieldscope.io/api/rates.json
- No API key, no signup, CORS enabled, HTTPS
- 37 CeFi venues, 1,425 coin-venue pairs, refreshed daily
- Each venue carries an A–F safety grade scored on five published risk criteria, and rates are base/flexible only — never promotional tiers
- Also includes the cheapest borrow rate per asset for 21 assets
- Free to use with attribution; the licence and field documentation are inside the feed itself