### PR TITLE
Add DepthFeed prediction-market liquidity benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 
 ## Prediction Markets
 
+- [DepthFeed Prediction Market Liquidity Benchmark](https://depthfeed.com/arena/liquidity) - `CSV` `JSON` `CC BY 4.0` - Reproducible 34,560-observation order-book study of BTC 15-minute markets across Polymarket, Kalshi, Predict.fun via Binance Wallet, and Limitless. [GitHub](https://github.com/vcorp-dev/prediction-market-liquidity-benchmark)
 - [pmxt](https://github.com/pmxt-dev/pmxt) - `Python` `JavaScript` - The CCXT for prediction markets. A unified API for trading on Polymarket, Kalshi, and more.
 - [polymarket-whales](https://github.com/al1enjesus/polymarket-whales) - `Python` - Real-time whale trade tracker for Polymarket — terminal alerts + Telegram notifications when large orders hit the book.
 - [Polymarket Scanner API](https://github.com/vesper-astrena/polymarket-scanner-api) - `Python` - Real-time arbitrage detection API for Polymarket prediction markets, scanning 12,000+ markets for mispricings.


### PR DESCRIPTION
## Summary

Adds the DepthFeed Prediction Market Liquidity Benchmark to the Prediction Markets section.

## Why it fits

- The v2.0.0 dataset contains 34,560 lifecycle-aligned order-book observations across Polymarket, Kalshi, Predict.fun via Binance Wallet, and Limitless.
- The row-level CSV, JSON artifact, methods, findings, checksum, citation metadata, and dependency-free verifier are public.
- The dataset and research are licensed CC BY 4.0; the verification code is MIT licensed.
- The repository is active and documents both usage and limitations.

## Validation

- Searched the README and open/closed pull requests; no existing DepthFeed entry was found.
- Confirmed the canonical report and GitHub repository are public.
- Ran `uv run python scripts/validate_readme.py --diff-from upstream/main`.

Disclosure: I am affiliated with DepthFeed.
