### PR TITLE
Add Filings Flow to Commercial & Proprietary Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Earnings Feed](https://earningsfeed.com/api) - Real-time SEC filings, insider trades, and institutional holdings API.
 - [EDGAR Events](https://edgarevents.com) - `REST` - SEC filing events as typed JSON: 8-K item codes with materiality flags, SC 13D/13G activist stakes (holder, target, percent of class), merger forms, and S-1/424B IPO filings, polled over REST or pushed via HMAC-signed webhooks, sourced from data.sec.gov.
 - [Financial Data](https://financialdata.net/) - Stock Market and Financial Data API.
+- [Filings Flow](https://filingsflow.com) - Free SEC 13F research web app covering 11,700+ institutional managers and 208,000+ filings from 2019 onward. Quarter-over-quarter position changes with share-based thresholds, confidential-treatment reveals badged, per-filing links to the EDGAR source document, and Excel export on every table. No account required.
 - [Frostbyte](https://agent-gateway-kappa.vercel.app) - Real-time crypto prices for 500+ tokens via REST API with free tier, DeFi swap routing and portfolio tracking.
 - [SaxoOpenAPI](https://www.developer.saxo/) - Saxo Bank financial data API.
 - [RTPR](https://rtpr.io) - Real-time press release API delivering news from Business Wire, PR Newswire, and GlobeNewswire with sub-500ms latency. REST and WebSocket APIs for financial applications. Python and Node.js SDKs available.


### PR DESCRIPTION
Adds Filings Flow — a free web app for researching SEC 13F institutional holdings.

Covers 11,743 managers and 208,545 filings from 2019 to present. Quarter-over-quarter position
changes are share-based with a stated ±5% threshold, confidential-treatment reveals are badged,
every filing links to its source document on EDGAR, and every table exports to Excel without an
account. Methodology is published: https://filingsflow.com/cite

On section placement: the product is free with no paid tier, but the codebase is private, so
per CONTRIBUTING I've put it under Commercial & Proprietary Services rather than a functional
category. This matches how other free-but-closed-source web apps in that section are handled
(Teses da Bolsa, StockVektor). Move it if you'd rather it sit elsewhere.

Actively maintained — data refreshes each quarter as filings land.