### PR TITLE
Add Jacobian to numerical libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [DataFrames.jl](https://github.com/JuliaData/DataFrames.jl) - `Julia` - In-memory tabular data in Julia.
 - [TSFrames.jl](https://github.com/xKDR/TSFrames.jl) - `Julia` - Handle timeseries data on top of the powerful and mature DataFrames.jl.
 - [TimeArrays.jl](https://github.com/bhftbootcamp/TimeArrays.jl) - `Julia` - Time series handling for Julia.
+- [jacobian](https://github.com/morluto/jacobian) - `Python` `MCP` - Exact computation and conjecture testing across polynomial maps, linear algebra, and graph algorithms for agent-driven mathematical research.
 
 ## Financial Instruments & Pricing
 


### PR DESCRIPTION
Adds Jacobian to Numerical Libraries & Data Structures. One README entry added; nothing else changed.

What it is: an MCP server, CLI, and Python library for exact computation and conjecture testing across polynomial maps, linear algebra, and graph algorithms.

Why it fits: this section already includes Python numerical and symbolic-mathematics libraries such as SciPy and SymPy. Jacobian adds an agent-facing tool for exact mathematical experiments rather than a finance-specific trading system.

Validation:
- `git diff --check`
- The entry follows the repository format and uses the `Python` and `MCP` tags.

