### PR TITLE
Add TerminalFin to Market Data & Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,6 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [BTC Orderbook Microstructure Research](https://github.com/whoareunot/btc-orderbook-research) - `Jupyter Notebook` - statistical analysis of Binance BTC/USDT orderbook: OBI, CVD, spread.  
 - [OpenBB Terminal](https://github.com/OpenBB-finance/OpenBBTerminal) - `Python` - Terminal for investment research for everyone.
 - [Fincept Terminal](https://github.com/Fincept-Corporation/FinceptTerminal) - `Python` - Advance Data Based A.I Terminal for all Types of Financial Asset Research.
-- [TerminalFin](https://terminalfin.com) - Free web terminal: central-bank rate-move probabilities computed from CFTC Swap Data Repository trades (BOJ/Fed/ECB/BOE/RBA, with a live published track record), swaption vol surfaces, FX-intervention tracking, cross-country macro, and Japan equity filings analytics (EDINET/JPX).
 - [yfinance](https://github.com/ranaroussi/yfinance) - `Python` - Yahoo! Finance market data downloader (+faster Pandas Datareader).
 - [treasurydirect](https://github.com/moshejs/treasurydirect) - `TypeScript` - Zero-dependency client for the US TreasuryDirect API: auction results, upcoming auctions, CUSIP lookups, and Debt to the Penny; no API key required.
 - [treasury-fiscaldata](https://github.com/moshejs/treasury-fiscaldata) - `TypeScript` - Typed client for the US Treasury FiscalData API (debt, average interest rates, exchange rates) with pagination and filtering; no API key required.
@@ -688,6 +687,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Reddit WallstreetBets API](https://tradestie.com/apps/reddit/api/) - Provides daily top 50 stocks from reddit (subreddit) Wallstreetbets and their sentiments via the API.
 - [System R](https://agents.systemr.ai) - AI-native risk intelligence API for trading agents. Position sizing, risk validation, and system health in one call.
 - [Telonex](https://telonex.io) - Tick-level prediction market data (trades, quotes, orderbooks, on-chain fills) via REST API and Python SDK.
+- [TerminalFin](https://terminalfin.com) - Free web terminal: central-bank rate-move probabilities computed from CFTC Swap Data Repository trades (BOJ/Fed/ECB/BOE/RBA, with a live published track record), swaption vol surfaces, FX-intervention tracking, cross-country macro, and Japan equity filings analytics (EDINET/JPX).
 - [ValueRay](https://www.valueray.com/api) - Technical, quantitative and sentiment data for stocks and ETFs with risk metrics, peer percentiles and market regime signals. Optimized for AI/LLM agents.
 - [VertData](https://vertdata.com) - Institutional-grade financial intelligence platform. Track 43K+ congressional trades (STOCK Act), SEC insider Form 4 filings, 25 superinvestor 13F portfolios, CFTC futures positioning, ARK ETF holdings, and short interest — all scored by AI for signal strength.
 - [KeepRule](https://keeprule.com/) - Curated library of decision-making principles and investment wisdom from masters like Buffett and Munger, featuring mental models for better investment thinking.

--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [BTC Orderbook Microstructure Research](https://github.com/whoareunot/btc-orderbook-research) - `Jupyter Notebook` - statistical analysis of Binance BTC/USDT orderbook: OBI, CVD, spread.  
 - [OpenBB Terminal](https://github.com/OpenBB-finance/OpenBBTerminal) - `Python` - Terminal for investment research for everyone.
 - [Fincept Terminal](https://github.com/Fincept-Corporation/FinceptTerminal) - `Python` - Advance Data Based A.I Terminal for all Types of Financial Asset Research.
+- [TerminalFin](https://terminalfin.com) - Free web terminal: central-bank rate-move probabilities computed from CFTC Swap Data Repository trades (BOJ/Fed/ECB/BOE/RBA, with a live published track record), swaption vol surfaces, FX-intervention tracking, cross-country macro, and Japan equity filings analytics (EDINET/JPX).
 - [yfinance](https://github.com/ranaroussi/yfinance) - `Python` - Yahoo! Finance market data downloader (+faster Pandas Datareader).
 - [treasurydirect](https://github.com/moshejs/treasurydirect) - `TypeScript` - Zero-dependency client for the US TreasuryDirect API: auction results, upcoming auctions, CUSIP lookups, and Debt to the Penny; no API key required.
 - [treasury-fiscaldata](https://github.com/moshejs/treasury-fiscaldata) - `TypeScript` - Typed client for the US Treasury FiscalData API (debt, average interest rates, exchange rates) with pagination and filtering; no API key required.


### PR DESCRIPTION
Adds [TerminalFin](https://terminalfin.com) — a free web-based financial terminal built on public data:

- Central-bank rate-move probabilities (BOJ, Fed, ECB, BOE, RBA) computed from meeting-dated OIS trades in the public CFTC Swap Data Repository tape, with a live published accuracy record (hit rate + Brier score, misses included)
- Swaption volatility surfaces derived from the same SDR tape
- Japan/US FX-intervention log with automatic strike detection
- Cross-country macro dashboards (GDP, CPI, debt, money & liquidity)
- Japan equity analytics from EDINET / JPX filings (large shareholders, short selling, activist signals)

Free to use, no registration required for the public pages. Placed next to the other terminal-style entries (OpenBB, Fincept) in Market Data & Data Sources.