### PR TITLE
Fix Korea Stock Data entry: correct link, drop inaccurate 'analyst consensus estimates'

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [PineForge](https://github.com/pineforge-4pass/pineforge-engine) - `C++` - Deterministic offline PineScript v6 → C++ backtest runtime, validated trade-for-trade against TradingView (245/246 strict, 0 engine bugs). Runs locally via Docker and is drivable by AI agents through a bundled MCP server.
 
 ## Market Data & Data Sources
-- [Korea Stock Data](https://github.com/na77tech-creator/korea-stock-data) - `Data` - Free daily dataset of top KOSPI/KOSDAQ stocks by market cap: prices, fundamentals, and analyst consensus estimates in CSV/JSON, updated every trading day, LLM/AI-readable.
+- [Korea Stock Data](https://github.com/na77tech-creator/aikstockdata) - `Data` - Free Korean equity data: KOSPI/KOSDAQ settled closes with 250 trading days of per-stock history, DART regulatory filings and earnings, published every trading day as JSON/CSV. No signup or API key, CORS open. OpenAPI 3.1 spec and MCP server included.
 - [BTC Orderbook Microstructure Research](https://github.com/whoareunot/btc-orderbook-research) - `Jupyter Notebook` - statistical analysis of Binance BTC/USDT orderbook: OBI, CVD, spread.  
 - [OpenBB Terminal](https://github.com/OpenBB-finance/OpenBBTerminal) - `Python` - Terminal for investment research for everyone.
 - [Fincept Terminal](https://github.com/Fincept-Corporation/FinceptTerminal) - `Python` - Advance Data Based A.I Terminal for all Types of Financial Asset Research.


### PR DESCRIPTION
Correcting my own entry from #463. Two things in it are wrong.

**1. The link is stale.** It points to `na77tech-creator/korea-stock-data`, which has not been updated since 2026-07-19 and, by its own description, does not serve raw quote data. The project is maintained at `na77tech-creator/aikstockdata`.

**2. The description claims "analyst consensus estimates". There are none.** The project redistributes Korean public-sector data only — FSS DART filings and the FSC open-data portal — and states plainly that it has no analyst ratings, no target prices, no PER/PBR and no investor-type flows. Claiming otherwise in a list people rely on is the wrong kind of wrong, and it is my mistake.

The replacement describes what is actually served:

- KOSPI/KOSDAQ settled closes (T+1), 250 trading days of history per stock
- DART regulatory filings and earnings
- JSON/CSV, no signup, no API key, no rate limit, CORS open
- OpenAPI 3.1 spec and an MCP server

Also freely available as a dataset: https://huggingface.co/datasets/aikstockdata/korea-equity-daily

One line changed, same section, same position, same name.