### PR TITLE
Point CONTRIBUTING to the site that exists

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Link to the PyPI package page. If the project has a GitHub repo, append it after
   Projects with a verifiable GitHub repository are easier to evaluate for source availability,
   documentation, activity, maintenance, and community adoption, and they receive automated
   tracking of stars, activity, and archive status on
-  [awesome-quant.com](https://awesome-quant.com/).
+  [the awesome-quant site](https://wilsonfreitas.github.io/awesome-quant/).
 - Include a GitHub repository either as the main project URL or as the exact
   `[GitHub](https://github.com/owner/repo)` suffix. A valid GitHub repository mentioned in
   either place receives the same relevance consideration.


### PR DESCRIPTION
# Point CONTRIBUTING to the site that exists

Branch: `fix/contributing-site-url` · 1 file changed, 1 insertion, 1 deletion

`CONTRIBUTING.md:65` tells contributors that a GitHub repository earns "automated tracking of
stars, activity, and archive status on [awesome-quant.com](https://awesome-quant.com/)".

That domain does not resolve.

```
$ nslookup awesome-quant.com
*** Non-existent domain

$ python -c "import socket; socket.getaddrinfo('awesome-quant.com', 443)"
socket.gaierror: [Errno 11001] getaddrinfo failed

$ curl -sSI https://awesome-quant.com/
curl: (6) Could not resolve host: awesome-quant.com
```

Same for `www.awesome-quant.com`. Three independent resolvers, NXDOMAIN on all three.

The site that `.github/workflows/build.yml` actually publishes lives on GitHub Pages:

```
$ gh api repos/wilsonfreitas/awesome-quant/pages
{"source": {"branch": "gh-pages", "path": "/"}, "cname": null, "status": "built",
 "html_url": "https://wilsonfreitas.github.io/awesome-quant/"}

$ curl -sS -o /dev/null -w '%{http_code}\n' https://wilsonfreitas.github.io/awesome-quant/
200
```

`cname` is `null` and there is no `CNAME` file in the repository, so the custom domain is not
configured on the Pages side either.

## The change

```diff
-  [awesome-quant.com](https://awesome-quant.com/).
+  [the awesome-quant site](https://wilsonfreitas.github.io/awesome-quant/).
```

One line. `scripts/validate_readme.py --diff-from origin/main` passes (README is untouched).

If `awesome-quant.com` is a domain you intend to register and point at the Pages deployment,
close this — it will fix itself the moment the DNS record exists.
