### PR TITLE
Add SmartQuant - AI quant trading learning hub (180 pages, 5 languages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,3 +710,4 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 
 - [awesome-sec-filings](https://github.com/vibeyclaw/awesome-sec-filings) - A curated list of tools, data sources, libraries, and resources for working with SEC filings (13F, 10-K, 10-Q, 8-K).
 - [CONVEXFI](https://github.com/convexfi) - Official GitHub organization for the convex research group at the Hong Kong University of Science and Technology (HKUST).
+- [SmartQuant](https://smartquanthq.com) - AI quant trading learning hub: 180 pages, 5 languages (EN/JA/KO/AR/ZH), free educational content on AI strategies, backtesting, and risk management.


### PR DESCRIPTION
Adding [SmartQuant](https://smartquanthq.com) to the Related Lists section — a free AI quant trading learning hub with 180 pages of educational content in 5 languages (ZH/EN/JA/KO/AR), covering AI strategies, backtesting, and risk management. All content is educational with risk disclaimers.