### PR TITLE
Add CoinLobster To Market Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [PineForge](https://github.com/pineforge-4pass/pineforge-engine) - `C++` - Deterministic offline PineScript v6 → C++ backtest runtime, validated trade-for-trade against TradingView (245/246 strict, 0 engine bugs). Runs locally via Docker and is drivable by AI agents through a bundled MCP server.
 
 ## Market Data & Data Sources
+- [CoinLobster](https://coinlobster.com/developers) - Web API for live executed crypto whale trades unified across 15 exchanges and on-chain DEX (Ethereum, Base, Arbitrum), with a keyless free tier, OpenAPI spec, and MCP server.
 - [Korea Stock Data](https://github.com/na77tech-creator/korea-stock-data) - `Data` - Free daily dataset of top KOSPI/KOSDAQ stocks by market cap: prices, fundamentals, and analyst consensus estimates in CSV/JSON, updated every trading day, LLM/AI-readable.
 - [BTC Orderbook Microstructure Research](https://github.com/whoareunot/btc-orderbook-research) - `Jupyter Notebook` - statistical analysis of Binance BTC/USDT orderbook: OBI, CVD, spread.  
 - [OpenBB Terminal](https://github.com/OpenBB-finance/OpenBBTerminal) - `Python` - Terminal for investment research for everyone.


### PR DESCRIPTION
Adds CoinLobster to Market Data & Data Sources.

CoinLobster is a hosted web API (same category of entry as Nasdaq Data Link, Portfolio Optimizer, and SwapAPI): live executed whale trades unified across 15 crypto exchanges plus on-chain DEX on Ethereum, Base and Arbitrum, with an unusualness radar and an outcome-scored flag ledger that is logged live and never backfilled. The free tier is permanent and needs no API key.

Machine-readable docs for tooling:
- OpenAPI spec: https://coinlobster.com/openapi.json
- llms.txt: https://coinlobster.com/llms.txt
- MCP server (keyless): https://coinlobster.com/mcp

Matches the existing entry format for hosted data sources (no language tag, one-sentence description ending with a period).