### PR TITLE
Add pyhood to Trading & Backtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Wickra](https://github.com/wickra-lib/wickra) - `Rust` `Python` `JavaScript` `C++` `C#` `Golang` `Java` `R` - Streaming-first technical-analysis library with a Rust core: 514 indicators updating in O(1) per tick, with bit-exact batch-vs-streaming results.
 
 ## Trading & Backtesting
+- [pyhood](https://github.com/jamestford/pyhood) - `Python` - Robinhood API client for unattended automation: after the first approved login, sessions renew from a stored refresh token with no password or device approval prompt. Covers stocks, equity and index options with Greeks, futures, IRA accounts, and the official Crypto Trading API.
 - [honest-signals](https://github.com/MarvinRey7879/honest-signals) - `Python` - Scores detected chart patterns against the pattern-free baseline for the same market, timeframe and horizon, reporting lift with cluster-robust confidence intervals instead of a hit rate against 50%.
 - [rulelint](https://github.com/momoddo/rulelint) - `Python` - Linter for mechanical trading-rule conditions: replays every condition over historical bars to catch look-ahead levels, dead branches that can never fire, and regime-drifted absolute thresholds before you trust a backtest.
 - [FAIG](https://github.com/tg12/FAIG) - `Python` - Fully automated trading bot for the IG Index platform (spread betting and CFDs), supporting demo and live accounts.


### PR DESCRIPTION
Adds [pyhood](https://github.com/jamestford/pyhood), a Python client for the Robinhood API.

```markdown
- [pyhood](https://github.com/jamestford/pyhood) - `Python` - Robinhood API client for unattended automation: after the first approved login, sessions renew from a stored refresh token with no password or device approval prompt. Covers stocks, equity and index options with Greeks, futures, IRA accounts, and the official Crypto Trading API.
```

There is currently no Robinhood client in the list, which seemed like a gap given how commonly it comes up.

What makes it worth listing rather than being another wrapper: the session model. Existing Robinhood libraries require a device approval tap on re-login, which is what breaks scheduled jobs. pyhood persists the refresh token and renews without credentials, so cron jobs and dashboards keep running.

Checklist against CONTRIBUTING:

- GitHub repository as the main URL
- Single `Python` tag, description ends with a period
- `https://` only
- Actively maintained: released 0.12.1 today, CI across Python 3.10 to 3.14, 360 tests, MIT licensed, [published on PyPI](https://pypi.org/project/pyhood/)

Happy to reword or move it if you would rather it sat elsewhere in the list.