### PR TITLE
Update Dados B3: own domain (dadosb3.com) and FII coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [FinanceDataReader](https://github.com/FinanceData/FinanceDataReader) - `Python` - Open Source Financial data reader for U.S, Korean, Japanese, Chinese, Vietnamese Stocks.
 - [pystlouisfed](https://github.com/TomasKoutek/pystlouisfed) - `Python` - Python client for Federal Reserve Bank of St. Louis API - FRED, ALFRED, GeoFRED and FRASER.
 - [python-bcb](https://github.com/wilsonfreitas/python-bcb) - `Python` - Python interface to Brazilian Central Bank web services.
-- [Dados B3](https://dados-b3.onrender.com) - `REST/MCP` - Fundamental data API for the Brazilian stock exchange (B3): ROIC, ROE, margins, point-in-time multiples, public methodology, free tier.
+- [Dados B3](https://dadosb3.com) - `REST/MCP` - Fundamental data API for Brazilian listed companies and real-estate funds (FIIs) on B3: ROIC, ROE, margins, point-in-time multiples, FII P/BV and dividend yield, public methodology, free tier.
 - [swiss-finance-data](https://github.com/EMen11/swiss-finance-data) - `Python` - Python package for Swiss financial data (SNB Policy Rate, SARON, CHF FX rates, CPI, SMI equities, Confederation bond yields) from official SNB sources.
 - [market-prices](https://github.com/maread99/market_prices) - `Python` - Create meaningful OHLCV datasets from knowledge of [exchange-calendars](https://github.com/gerrymanoim/exchange_calendars) (works out-the-box with data from Yahoo Finance).
 - [tardis-python](https://github.com/tardis-dev/tardis-python) - `Python` - Python interface for Tardis.dev high frequency crypto market data.


### PR DESCRIPTION
Small follow-up to the existing Dados B3 entry (merged in #553): point the link to the project's own domain (dadosb3.com, replacing the old onrender.com URL) and note the newly added Brazilian real-estate fund (FII) coverage — FII P/BV and dividend yield. One-line change, still under Data Sources.