### PR TITLE
Add Quant Sprint to Reproducing Works, Training & Books

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [godzilla.dev](https://godzilla.dev) - `C++` `Python` - Open-source framework for crypto quant trading, funding rate arbitrage and ultra-low-latency market making. [GitHub](https://github.com/godzilla-foundation/godzilla-community)
 
 ## Reproducing Works, Training & Books
+- [Quant Sprint](https://lambdia.com/play) - `Training` `Interviews` - Free timed drill of first round quant interview questions on options and the Greeks, two sided quoting, probability and mental arithmetic.
 - [Wyckoff Method Course](https://arapov.trade/en/freestudying/wyckoff-method) - Free course on volume analysis and the Wyckoff method: market phases, spring/upthrust, order flow reading.
 - [Special-Relativity-in-Financial-Modeling](https://github.com/Mattbusel/Special-Relativity-in-Financial-Modeling) - C++20 implementation of special-relativistic geometry applied to OHLCV data: Lorentz factors, spacetime intervals, Christoffel symbols, and geodesic deviation signals from live market data. DOI: 10.5281/zenodo.18639919.
 - [Auto-Differentiation Website](https://auto-differentiation.github.io/) - Background and  resources on Automatic Differentiation (AD) / Adjoint Algorithmic Differentitation (AAD).


### PR DESCRIPTION
Adds one entry: [Quant Sprint](https://lambdia.com/play).

A free browser drill for first round quant interview questions. A run starts at 72 seconds, right answers buy time back, wrong ones cost four. Questions are drawn rather than written: a price above or below a strike, a quote with one side rubbed out, a payoff curve, a dot grid for a Bayes question. The deck covers options and the Greeks, two sided quoting, probability, brainteasers and mental arithmetic.

I put it under Reproducing Works, Training & Books next to the Wyckoff course, since that is where the free training resources without a repository already sit. It is a hosted site rather than a library, so if the list is meant to stay libraries and notebooks only, say so and I will close this.

Disclosure: I built it. Free, no account, no network calls.