### PR TITLE
Add hft-engine-rs to Trading & Backtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [TDAmeritrade.DotNetCore](https://github.com/NVentimiglia/TDAmeritrade.DotNetCore) - `CSharp` - Free, open-source .NET Client for the TD Ameritrade Trading Platform. Helps developers integrate TD Ameritrade API into custom trading solutions.
 - [Barter](https://github.com/barter-rs/barter-rs) - `Rust` - Open-source Rust framework for building event-driven live-trading & backtesting systems.
 - [LFEST](https://github.com/MathisWellmann/lfest-rs) - `Rust` - Simulated perpetual futures exchange to trade your strategy against.
+- [hft-engine-rs](https://github.com/Ninian-Lemain/hft-engine-rs) - `Rust` - Deterministic, allocation-free execution gateway and price-time matching engine foundation.
 - [OpenFinClaw](https://github.com/cryptoSUN2049/openFinclaw) - `Python` `Rust` - AI-native one-person hedge fund platform with Rust trading engine. Natural language → strategy → backtest → execution in 60s. Multi-market (US/HK/CN/Crypto), self-evolving strategy pipeline. Built on OpenClaw (68K+ stars).
 - [Sextant](https://github.com/raphaub-hub/SEXTANT) - `Python` - Local event-driven backtesting engine with no-code strategy builder and FRED vintage, ALFRED, yFinance support.
 


### PR DESCRIPTION
Add [hft-engine-rs](https://github.com/Ninian-Lemain/hft-engine-rs) — a deterministic, allocation-free execution gateway and price-time matching engine foundation in Rust.