### PR TITLE
Add Live Tennis API to Prediction Markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Oracle3](https://github.com/YichengYang-Ethan/oracle3) - `Python` - Autonomous trading agent for Kalshi, Polymarket, and Solana — Wang Transform pricing (calibrated on 291k resolved contracts) drives eight constraint-based arbitrage strategies and Kelly-sized model trades.
 - [marketlens](https://github.com/marketlenstrade/marketlens-python) - `Python` `MCP` - Tick-level Polymarket order book history with replay and a backtesting engine simulating queue priority, latency, and slippage.
 - [polymarket-bot-lab](https://github.com/oraclemangle/polymarket-bot-lab) - `Python` - Open-sourced research lab of 11 candidate Polymarket trading bots (weather, sports, longshot fades, maker, whale-flow) with a shared CLOB/backtest framework, ADR decision log, and honest paper/live results. Companion free dataset: [polymarket-canary-tape](https://huggingface.co/datasets/oraclemangle/polymarket-canary-tape) (300M+ events, CC-BY-4.0).
+- [Live Tennis API](https://livetennisapi.com) - `REST` `WebSocket` `MCP` - Real-time tennis scores, serving and break-point state, and model win probabilities for pricing tennis event markets, plus H2H, rankings and a 1968-2022 point-by-point archive; free tier. [GitHub](https://github.com/livetennisapi/livetennisapi-mcp)
 
 ## Calendars & Market Hours
 


### PR DESCRIPTION
One entry for the Prediction Markets section: Live Tennis API — the event-side data feed for tennis event-contract trading (real-time scores, serving/break-point state, model win probabilities over REST/WebSocket, plus an MCP server for agent workflows; H2H, rankings and a 1968–2022 point-by-point archive for backtesting). Free tier available.

Format follows CONTRIBUTING (tags, one sentence, period before the GitHub suffix). Disclosure: I run this API. Repo linked is our MCP server (190★), MIT.