### PR TITLE
Add Options Strategy Backtester with reproducible examples and results to Trading & Backtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Wickra](https://github.com/wickra-lib/wickra) - `Rust` `Python` `JavaScript` `C++` `C#` `Golang` `Java` `R` - Streaming-first technical-analysis library with a Rust core: 514 indicators updating in O(1) per tick, with bit-exact batch-vs-streaming results.
 
 ## Trading & Backtesting
+- [ERN-WO Options Backtester](https://github.com/Javier-Garzo/ern-wo-options-backtester) - `Java` `Spring Boot` - Streaming backtesting engine for short-duration index options with conservative five-minute execution modeling and reproducible Early Retirement Now and WealthyOption strategy replication results.
 - [midas-core](https://github.com/w2ur/midas-core) - `Python` - Multi-agent paper-trading framework where LLM agents author orders and a separate broker process enforces fifteen fill-time safety rails; each fill is stamped with the git commit it executed against for reproducibility.
 - [Manifold-BT](https://github.com/manifoldbt/manifoldbt) - `Python` `Rust` - High-performance Rust-powered backtesting engine for quantitative research with parameter sweeps, walk-forward and Monte Carlo.
 - [mkt-alerts](https://github.com/dzianisv/mkt-alerts) - `TypeScript` - Self-hosted market-alert daemon: price, RSI/MACD/SMA conditions, and full Pine Script v5 custom indicators evaluated off-TradingView, on crypto (Coinbase) and stocks (Yahoo Finance) with no API key, delivered via ntfy push, email, or Telegram.


### PR DESCRIPTION
## Summary

Adds [ERN-WO Options Backtester](https://github.com/Javier-Garzo/ern-wo-options-backtester) to the Trading & Backtesting section.

It is an open-source Java and Spring Boot engine for backtesting short-duration index-option strategies using streaming intraday data and conservative five-minute execution modeling. It includes ready-to-run API request examples and published, reproducible results for Early Retirement Now and WealthyOption strategy replications.

## Checklist

- One project and one README entry.
- Placed under Trading & Backtesting.
- Active public GitHub repository.
- README includes reproduction instructions, ready-to-run examples, and published results.
- Entry follows the required tag and description format.
- Existing README and previous pull requests checked for duplicates.
- `python scripts/validate_readme.py --diff-from origin/main` passed.