### PR TITLE
Add QuantVault (quant interview prep, free tier)

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 
 ## Reproducing Works, Training & Books
 - [Quant Sprint](https://lambdia.com/play) - `Training` `Interviews` - Free timed drill of first round quant interview questions on options and the Greeks, two sided quoting, probability and mental arithmetic.
+- [QuantVault](https://quantvault.org) - `Training` `Interviews` - Quant interview prep with 391 free problems with full worked solutions, per-firm online-assessment guides, and free playable replicas of real trading-firm OAs (Optiver, SIG, IMC).
 - [Wyckoff Method Course](https://arapov.trade/en/freestudying/wyckoff-method) - Free course on volume analysis and the Wyckoff method: market phases, spring/upthrust, order flow reading.
 - [Special-Relativity-in-Financial-Modeling](https://github.com/Mattbusel/Special-Relativity-in-Financial-Modeling) - C++20 implementation of special-relativistic geometry applied to OHLCV data: Lorentz factors, spacetime intervals, Christoffel symbols, and geodesic deviation signals from live market data. DOI: 10.5281/zenodo.18639919.
 - [Auto-Differentiation Website](https://auto-differentiation.github.io/) - Background and  resources on Automatic Differentiation (AD) / Adjoint Algorithmic Differentitation (AAD).


### PR DESCRIPTION
Adds [QuantVault](https://quantvault.org) to the Reproducing Works, Training & Books section, next to the existing Quant Sprint interviews entry.

QuantVault is a quant interview prep platform with a substantial free tier: 391 free problems with full worked step-by-step solutions (no account needed), per-firm online-assessment format guides, and free playable replicas of real trading-firm OAs (Optiver's game suite, SIG's quantitative evaluation, IMC's cognitive screen).

Entry follows the multiple-tag format from CONTRIBUTING.md with a period-terminated description.