### PR TITLE
Add dsh-quant to Quant Research Environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 
 ## Quant Research Environments
 
+- [dsh-quant](https://github.com/pengpengyi92/dsh-quant) - `TypeScript` `DeepSeek Harness` - Agent-native quantitative research toolkit for DeepSeek Harness: 46 tools across data, alpha, ML, risk, execution and ecosystem domains, with an end-to-end research pipeline.
 - [Jupyter Quant](https://github.com/gnzsnz/jupyter-quant) - `Python` - A dockerized Jupyter quant research environment with preloaded tools for quant analysis, statsmodels, pymc, arch, py_vollib, zipline-reloaded, PyPortfolioOpt, etc.
 
 ## Cross-Language Frameworks


### PR DESCRIPTION
Adds dsh-quant, an agent-native quantitative R&D toolkit for DeepSeek Harness (46 tools across 6 domains, TypeScript, zero runtime dependencies, MIT). Entry follows the tag format.