### PR TITLE
Add QFO Quant Platform to Quant Research Environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 
 ## Quant Research Environments
 
+- [QFO Quant Platform](https://www.qfo-quant-platform.com/) - `Python` `React` `A-shares` - Local-first quantitative research and backtesting platform with data synchronization, multi-asset screening, factor analysis, portfolio optimization, risk analysis, and optional LLM-assisted news analysis. [GitHub](https://github.com/yeh2017/QFO-Quant-Platform)
 - [dsh-quant](https://github.com/pengpengyi92/dsh-quant) - `TypeScript` `DeepSeek Harness` - Agent-native quantitative research toolkit for DeepSeek Harness: 46 tools across data, alpha, ML, risk, execution and ecosystem domains, with an end-to-end research pipeline.
 - [Jupyter Quant](https://github.com/gnzsnz/jupyter-quant) - `Python` - A dockerized Jupyter quant research environment with preloaded tools for quant analysis, statsmodels, pymc, arch, py_vollib, zipline-reloaded, PyPortfolioOpt, etc.
 


### PR DESCRIPTION
## Project

QFO Quant Platform is a free and open-source, local-first quantitative
research and backtesting platform focused on China A-shares.

## Why it fits

- Provides an end-to-end quantitative research environment.
- Covers data synchronization, stocks, ETFs and convertible bonds.
- Includes factor research, backtesting, portfolio optimization and risk analysis.
- Actively maintained with installation documentation and a stable release.
- Licensed under the MIT License.

Repository:
https://github.com/yeh2017/QFO-Quant-Platform