### PR TITLE
Add QuantRank500 to Prediction Markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Live Tennis API](https://livetennisapi.com) - `REST` `WebSocket` `MCP` - Real-time tennis scores, serving and break-point state, and model win probabilities for pricing tennis event markets, plus H2H, rankings and a 1968-2022 point-by-point archive; free tier. [GitHub](https://github.com/livetennisapi/livetennisapi-mcp)
 - [polymm](https://github.com/kachence/polymm) - `Python` `Polymarket` - Market-making and arbitrage bot for Polymarket sports and esports markets, pricing from de-vigged sportsbook odds.
 
+- [QuantRank500](https://github.com/quantrank500/quantrank500) - `Python` - Open-source public record of stock predictions: commit-reveal before the open, automatic settlement against exchange data, tamper-evident hash-chained ledger. Live at [quantrank500.com](https://quantrank500.com).
 
 ## Calendars & Market Hours
 


### PR DESCRIPTION
Adds QuantRank500 - an open-source public record of stock predictions.

- Predictions are cryptographically committed before the market opens
  (commit-reveal), revealed at 9:30 AM ET, and settled automatically
  against exchange trade records.
- INSERT-only, hash-chained ledger - tamper-evident, independently
  verifiable; ledger data is CC0.
- MIT licensed, Python (FastAPI/Postgres), tests run publicly in CI.

Repo: https://github.com/quantrank500/quantrank500
Live: https://quantrank500.com