### PR TITLE
Add AxionQuant to Commercial and Proprietary Services section

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [TradeMux Snippets](https://github.com/KVignesh122/trademux-examples) - `Python` - Code snippets for Metatrader (MT5) forex/CFD trading and data retrieval via trademux API client.
 
 ## Commercial & Proprietary Services
+- [AxionQuant](https://axionquant.com) - Unified financial data API covering market prices, fundamentals, disclosures, macroeconomic, and alternative data for long-horizon research and quantitative modeling. Free tier: 1,000 monthly API calls. [PyPI](https://pypi.org/project/axionquant-sdk/)
 - [Prop Firm Risk Calculator](https://prop-firm-risk-calculator.vercel.app) - Free web app for position sizing, stop-loss and max-drawdown on funded accounts, with real tick/pip values for futures, forex, crypto and gold.
 - [AlphaForge](https://alforgelabs.com) - `Python` - Local-first agent-native quant CLI with Optuna TPE optimization, walk-forward testing, anti-overfitting guards, and TradingView Pine v6 code generation. Free trial available. [GitHub](https://github.com/alforge-labs/alpha-forge-mcp)
 - [TradeMux](https://trademux.io) - Unified forex trading API gateway to Metatrader (MT4/MT5), Oanda and cTrader.


### PR DESCRIPTION
## What

Adds [AxionQuant](https://axionquant.com) - a unified financial data API covering market prices, fundamentals, disclosures, macroeconomic, and alternative data - to the `Commercial & Proprietary Services` section.

## Why this placement

- Hosted commercial API with paid plans (Starter $49.99/mo, Pro $199.99/mo) plus a **permanent free tier**: 1,000 API calls/month, 1 year of historical data, no card required.
- Public pricing and free-tier limits published at https://axionquant.com/pricing.
- Public API docs, SDKs (Python on PyPI, JavaScript, C), MCP server, and tutorials are available.
- Its GitHub/C/PyPI repositories are thin SDK/integration clients, so per CONTRIBUTING.md it is treated as repository-less and placed in the commercial section.
- No duplicate entry exists; format matches the parser regex and `validate_readme.py` passes.

## Note

The PyPI SDK is at https://pypi.org/project/axionquant-sdk/.