### PR TITLE
Add biquote to Market Data & Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [PineForge](https://github.com/pineforge-4pass/pineforge-engine) - `C++` - Deterministic offline PineScript v6 → C++ backtest runtime, validated trade-for-trade against TradingView (245/246 strict, 0 engine bugs). Runs locally via Docker and is drivable by AI agents through a bundled MCP server.
 
 ## Market Data & Data Sources
+- [biquote](https://biquote.io) - Free real-time forex, gold, crypto and index CFD market data API (REST + WebSocket): live quotes for ~280 instruments, OHLC candles and an economic calendar covering 54 countries. No API key or signup, 15,000 requests/min.
 - [Korea Stock Data](https://github.com/na77tech-creator/aikstockdata) - `Data` - Free Korean equity data: KOSPI/KOSDAQ settled closes with 250 trading days of per-stock history, DART regulatory filings and earnings, published every trading day as JSON/CSV. No signup or API key, CORS open. OpenAPI 3.1 spec and MCP server included.
 - [BTC Orderbook Microstructure Research](https://github.com/whoareunot/btc-orderbook-research) - `Jupyter Notebook` - statistical analysis of Binance BTC/USDT orderbook: OBI, CVD, spread.  
 - [OpenBB Terminal](https://github.com/OpenBB-finance/OpenBBTerminal) - `Python` - Terminal for investment research for everyone.


### PR DESCRIPTION
Adds [biquote](https://biquote.io) — a free real-time market data API for quants working with FX, metals and crypto.

- REST + WebSocket (SignalR); live quotes for ~280 instruments from a MetaTrader 5 feed
- OHLC candles (1m–1d) and an economic calendar covering 54 countries
- No API key, no signup; 15,000 requests/min per IP
- Python client on PyPI and JS client on npm (`biquote`); docs at https://biquote.io/docs/ and llms.txt at https://biquote.io/llms.txt

Honest scope note: CFD pricing, so no exchange-licensed equities and no volume data — it complements rather than replaces the equity-focused sources in this section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)