### PR TITLE
Add orderbook to Trading & Backtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [wickworks](https://github.com/psyb0t/docker-wickworks) - `REST` `MCP` - Stateless OHLC analyzer: POST bars and requested indicators, get back RSI/MACD/Bollinger/ADX/ATR/VWAP/Ichimoku plus smart-money-concept primitives (order blocks, FVGs, BOS/CHoCH, swing structure). No database, no AI signals.
 
 ## Trading & Backtesting
+- [orderbook](https://github.com/intrepidkarthi/orderbook) - `Go` `WebAssembly` - Embeddable limit order book and matching engine with integer-exact pricing, a single-writer core and write-ahead-log crash recovery, plus a microstructure research harness whose order-flow-imbalance, Kyle's lambda and CVD studies are measured against simulator ground truth.
 - [ERN-WO Options Backtester](https://github.com/Javier-Garzo/ern-wo-options-backtester) - `Java` `Spring Boot` - Streaming backtesting engine for short-duration index options with conservative five-minute execution modeling and reproducible Early Retirement Now and WealthyOption strategy replication results.
 - [midas-core](https://github.com/w2ur/midas-core) - `Python` - Multi-agent paper-trading framework where LLM agents author orders and a separate broker process enforces fifteen fill-time safety rails; each fill is stamped with the git commit it executed against for reproducibility.
 - [Manifold-BT](https://github.com/manifoldbt/manifoldbt) - `Python` `Rust` - High-performance Rust-powered backtesting engine for quantitative research with parameter sweeps, walk-forward and Monte Carlo.


### PR DESCRIPTION
Adding [orderbook](https://github.com/intrepidkarthi/orderbook) — an embeddable limit order book and matching engine in Go, plus a market-microstructure research harness built on it.

**Entry**

```
- [orderbook](https://github.com/intrepidkarthi/orderbook) - `Go` `WebAssembly` - Embeddable limit order book and matching engine with integer-exact pricing, a single-writer core and write-ahead-log crash recovery, plus a microstructure research harness whose order-flow-imbalance, Kyle's lambda and CVD studies are measured against simulator ground truth.
```

**Why it fits this list**

The engine is its own data source: it emits per-order (L3 / market-by-order) event streams, and the simulator provides ground truth, so the three studies in `docs/research/` can be checked rather than asserted. They mostly *refute* the popular claims:

- **Order-flow imbalance** — contemporaneous R² ≈ 0.24, predictive R² ≈ 0.0004, a ~577× gap, and the little that remains points the other way.
- **Kyle's λ** — measured end to end, why it scales as 1/depth, and what a block order costs against working the same quantity.
- **Delta / CVD / absorption** — a 94.5%-accurate aggressor rule builds a CVD wrong by 169%, and CVD divergence loses to a price-only control.

Also included: an Avellaneda–Stoikov market-making backtest, a deterministic exchange simulator, market-abuse surveillance detectors, and a uniform-price call auction.

**Checklist**

- [x] `https://` URL, GitHub repo as the primary link
- [x] Tags in separate backtick pairs, description is one sentence ending with a period
- [x] Not archived; active commits (latest release v0.26.0, today)
- [x] README with usage examples; runnable examples on [pkg.go.dev](https://pkg.go.dev/github.com/intrepidkarthi/orderbook/pkg/matching#pkg-examples)
- [x] MIT licensed
- [x] Searched the README and open PRs for duplicates — not previously listed
- [x] `scripts/validate_readme.py --diff-from main` passes locally, and `site/generate.py` runs clean

**Disclosure:** I'm the author of the project.

One note in the interest of not overselling it: the project is explicit that it is an experiment rather than a product — it has never run a live market, and [docs/PRODUCTION-READINESS.md](https://github.com/intrepidkarthi/orderbook/blob/main/docs/PRODUCTION-READINESS.md) says so at length. It is listed here for the research harness and as a readable, tested matching core, not as venue software.