### PR TITLE
Add Algorier to Commercial & Proprietary Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,6 +752,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [0xArchive](https://0xarchive.io) - Real-time and historical Hyperliquid and Lighter market data through REST, WebSocket, MCP, SDKs, CLI, and replay, with a permanent free tier.
 - [TickerAll](https://tickerall.com) - Hosted MetaTrader 5 & MT4 broker API (REST + WebSocket) to connect broker accounts, stream live ticks, fetch historical candles, and place or manage trades from code without a local terminal; permanent free tier with no card, real-time market data, and demo trading, with paid plans for live trading and higher limits. [Docs](https://tickerall.com/docs)
 - [Wiseek Filing Impact](https://wiseek.ai/datasets/) - Monthly statistics relating proprietary SEC-filing importance scores to next-session excess stock moves, with per-event data, reproduction metadata, and a CC BY 4.0 license. [GitHub](https://github.com/WiseekAI/wiseek-datasets)
+- [Algorier](https://algorier.com) - `AI` `Vibe-Trading` - Natural-language strategy builder that generates, backtests and forward-tests an algorithm from a plain-English description, deploys it to the user's own broker account across forex, crypto, metals, indices, CFDs and equities on 15 brokers (Interactive Brokers, Binance, Bybit, Oanda, Coinbase, IC Markets, Pepperstone and others), and lets creators sell strategies on its AlgoNetwork marketplace without revealing the underlying logic. Permanent free tier: 2 backtests and 40 assistant messages a month, no payment details required.
 
 
 ## Related Lists


### PR DESCRIPTION
Adds Algorier to `Commercial & Proprietary Services`.

- **Link:** https://algorier.com — stable HTTPS, no tracking or affiliate parameters
- **What it does:** users describe a strategy in plain language ("vibe trading"); the platform generates the algorithm, backtests and forward-tests it, and deploys it to the user's own broker account — forex, crypto, metals, indices, CFDs, futures and equities across 15 brokers including Interactive Brokers, Binance, Bybit, Oanda and Coinbase.
- **Private-logic marketplace:** creators can sell a strategy on AlgoNetwork; buyers run it without seeing the underlying logic.
- **Free tier:** permanent — 2 backtests and 40 AI assistant messages per month, no payment details required, no trial expiry.
- **Pricing:** https://algorier.com/pricing
- **Methodology / documentation:** https://algorier.com/blog/publishing-guide/ — publishing thresholds (Sortino > 1, profit-to-max-drawdown > 1, > 100 trades) and how they are computed.

**Disclosure: I work on Algorier.** Happy to adjust wording, section placement, or trim to house style.

Ran `python scripts/validate_readme.py --diff-from upstream/main` — `Validated 1 entries`, validation passed. Entry placed in the commercial section per CONTRIBUTING, with optional domain tags.
