### PR TITLE
Add SEC Form 4 API to Market Data & Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [EarningsCall](https://github.com/EarningsCall/earningscall-python) - `Python` - REST API and Python/JavaScript SDK for earnings call transcripts, audio files, and slide decks for 9,000+ public companies. Includes speaker-level data, Q&A segmentation, and earnings calendar.
 - [Korean Market Data](https://github.com/james-brand/korea-market-data) - `Data` - Daily foreign and institutional net flows for every KOSPI/KOSDAQ common stock plus all 44 KRX sector indices with returns and excess return vs market, in English CSV/JSON under CC BY 4.0 with a Zenodo DOI, rebuilt each trading day.
 - [AgentServices](https://agentservices.to) - `Python` - x402-paid crypto and market data API platform: 54 services, 97 endpoints, 37 MCP tools. Real-time prices, technical indicators, on-chain data, and market intelligence with on-chain USDC payments on Base. [GitHub](https://github.com/vbkotecha/aiservices-api)
+- [SEC Form 4 API](https://documenter.getpostman.com/view/57719789/2sBYAsyCVM) - `API` - Normalized SEC Form 4 insider-trading transactions (buys, sells, holdings) as clean JSON, for insider-cluster screening and event-driven signals.
 
 
 ## Prediction Markets


### PR DESCRIPTION
Adds one data-source entry: a normalized SEC Form 4 insider-trading API (clean JSON) for insider-cluster screening and event-driven signal research. Follows CONTRIBUTING.md's single-tag entry format.