### PR TITLE
Add Planar.jl to Trading & Backtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [PROJ_Option_Pricing_Matlab](https://github.com/jkirkby3/PROJ_Option_Pricing_Matlab) - `Matlab` - Quant Option Pricing - Exotic/Vanilla: Barrier, Asian, European, American, Parisian, Lookback, Cliquet, Variance Swap, Swing, Forward Starting, Step, Fader.
 - [Fastback.jl](https://github.com/rbeeli/Fastback.jl) - `Julia` - Blazing fast Julia backtester.
 - [Lucky.jl](https://github.com/oliviermilla/Lucky.jl) - `Julia` - Modular, asynchronous trading engine in pure Julia.
-- [Planar.jl](https://github.com/BubbleParticles/Planar.jl) - `Julia` - Advanced trading bot framework built around CCXT (100+ exchanges) with Zarr-backed OHLCV persistence, contiguity-checked data feeds, isolated/cross margin support, and a functional loop backtester with by-simulation and unified sim/paper/live strategy code.
+- [Planar.jl](https://github.com/BubbleParticles/Planar.jl) - `Julia` - Trading framework built around CCXT with Zarr-backed OHLCV persistence, contiguity-checked data feeds, isolated-margin position management, and a loop-based backtester sharing strategy code across simulation, paper, and live modes.
 - [Strategems.jl](https://github.com/dysonance/Strategems.jl) - `Julia` - Quantitative systematic trading strategy development and backtesting.
 - [ccxt](https://github.com/ccxt/ccxt) - `JavaScript` `Python` `PHP` - A JavaScript / Python / PHP cryptocurrency trading API with support for more than 100 bitcoin/altcoin exchanges.
 - [binance-fix-connector-python](https://github.com/AlexanderMerkel/binance-fix-connector-python) - `Python` - Async Python connector for Binance Spot FIX sessions with Order Entry, Market Data, and Drop Copy support.

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [PROJ_Option_Pricing_Matlab](https://github.com/jkirkby3/PROJ_Option_Pricing_Matlab) - `Matlab` - Quant Option Pricing - Exotic/Vanilla: Barrier, Asian, European, American, Parisian, Lookback, Cliquet, Variance Swap, Swing, Forward Starting, Step, Fader.
 - [Fastback.jl](https://github.com/rbeeli/Fastback.jl) - `Julia` - Blazing fast Julia backtester.
 - [Lucky.jl](https://github.com/oliviermilla/Lucky.jl) - `Julia` - Modular, asynchronous trading engine in pure Julia.
+- [Planar.jl](https://github.com/BubbleParticles/Planar.jl) - `Julia` - Advanced trading bot framework built around CCXT (100+ exchanges) with Zarr-backed OHLCV persistence, contiguity-checked data feeds, isolated/cross margin support, and a functional loop backtester with by-simulation and unified sim/paper/live strategy code.
 - [Strategems.jl](https://github.com/dysonance/Strategems.jl) - `Julia` - Quantitative systematic trading strategy development and backtesting.
 - [ccxt](https://github.com/ccxt/ccxt) - `JavaScript` `Python` `PHP` - A JavaScript / Python / PHP cryptocurrency trading API with support for more than 100 bitcoin/altcoin exchanges.
 - [binance-fix-connector-python](https://github.com/AlexanderMerkel/binance-fix-connector-python) - `Python` - Async Python connector for Binance Spot FIX sessions with Order Entry, Market Data, and Drop Copy support.


### PR DESCRIPTION
### Addition: Planar.jl

**URL:** https://github.com/BubbleParticles/Planar.jl

**Section:** Trading & Backtesting (Julia)

**Entry:**
```markdown
- [Planar.jl](https://github.com/BubbleParticles/Planar.jl) - `Julia` - Advanced trading bot framework built around CCXT (100+ exchanges) with Zarr-backed OHLCV persistence, contiguity-checked data feeds, isolated/cross margin support, and a functional loop backtester with by-simulation and unified sim/paper/live strategy code.
```

**What it is:**
Planar.jl is an advanced Julia framework for building your own trading bot. Primarily built around the [CCXT](https://github.com/ccxt/ccxt) API (100+ crypto exchanges) but extendable to any custom exchange. It provides:

- **Live-first data integrity** — Zarr-backed OHLCV persistence with contiguity checks (no missing candles), progressive chunk access, and a standardized fetch/process/store data-feed interface.
- **Margin & leverage** — type hierarchy for isolated/cross margin, hedged/unhedged positions.
- **Functional backtester** — synchronous loop-based simulation (not event-driven), self-contained, fast, easy to parallelize, with identical strategy code across `sim`/`paper`/`live` modes.
- **By-simulation** — fine-grained order/trade simulation that can run *during* live trading to tune against the exchange or detect exchange misbehavior.
- **Thin abstractions** — strategies send orders directly; no signal-in-the-middle. Plotting, parameter optimization (grid/evolution/Bayesian), Telegram control, and Docker/sysimage distribution included.

Julia 1.9+, distributed via [PlanarRegistry](https://github.com/BubbleParticles/PlanarRegistry) (`Pkg.add("Planar")`), Docker images, and `planarjl-py` on PyPI.

**Why it fits:**
- Complements existing Julia entries (Fastback.jl, Lucky.jl, Strategems.jl) with a production-oriented, exchange-connected framework — the only Julia entry with full CCXT live-trading coverage plus paper trading via real order-book simulation.
- Active maintenance: the framework is under continuous development with CI (tests, docs, Docker) and real live-trading usage.
- Licensed Apache-2.0, public GitHub repo with substantive implementation, clear README, docs at https://planar.pages.dev/docs/.

**Affiliation disclosure:** Contributor to Planar.jl (BubbleParticles org).

**Checklist:**
- [x] Entry follows CONTRIBUTING.md format (`[Name](url) - \`Julia\` - description.`)
- [x] Placed in correct category (Trading & Backtesting) in alphabetical order (after Lucky.jl, before Strategems.jl)
- [x] Uses `https://` and GitHub repo as main URL
- [x] Description ends with a period, one concise sentence
- [x] Not a duplicate (searched README and closed PRs)
- [x] Repo shows recent activity and has clear README/docs