### PR TITLE
Add outcometick under Prediction Markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [polymm](https://github.com/kachence/polymm) - `Python` `Polymarket` - Market-making and arbitrage bot for Polymarket sports and esports markets, pricing from de-vigged sportsbook odds.
 
 - [QuantRank500](https://github.com/quantrank500/quantrank500) - `Python` - Open-source public record of stock predictions: commit-reveal before the open, automatic settlement against exchange data, tamper-evident hash-chained ledger. Live at [quantrank500.com](https://quantrank500.com).
+- [outcometick](https://outcometick.com) - `Python` `JavaScript` - Tick-level history for Polymarket and Predict.fun crypto Up/Down markets, including the full-precision Chainlink settlement feeds and each market's strike and settled outcome, with a sandboxed runner that replays a submitted strategy against the same archive. [GitHub](https://github.com/outcometick/outcometick-sdk-ts)
 
 ## Calendars & Market Hours
 


### PR DESCRIPTION
Adds **outcometick** under `## Prediction Markets`, at the end of the section.

### What it is

Tick-level historical data for Polymarket and Predict.fun crypto Up/Down markets, with a sandboxed runner that replays a submitted strategy against the same archive.

### Why it is different from the neighbouring entries

The archive carries the **Chainlink settlement feeds these markets actually resolve against**, at full fixed-point precision, together with each market'''s strike and settled outcome. That lets a researcher recompute every win and loss from the source instead of trusting a supplied label — the other data entries in this section carry the book and the prints, but not the settlement basis. It also covers Predict.fun, not only Polymarket.

### Eligibility

Per CONTRIBUTING, placement in a functional section is supported by a public repository containing substantive implementation:

- **[outcometick/outcometick-sdk-ts](https://github.com/outcometick/outcometick-sdk-ts)** — the strategy SDK plus the `ot` CLI: manifest and hook validation, the static analyser that gates submissions, and a local replay engine. Published as [outcometick on npm](https://www.npmjs.com/package/outcometick).
- **[outcometick/outcometick-sdk-python](https://github.com/outcometick/outcometick-sdk-python)** — the Python SDK, published as [outcometick on PyPI](https://pypi.org/project/outcometick/).

Both repositories carry their own test suites and CI, and both were updated this month.

### Checkable claims

Every figure in the description can be verified without an account:

- Coverage, venues, assets and date range: <https://outcometick.com/v1/public/coverage>
- Machine-readable product summary: <https://outcometick.com/llms.txt>
- Free sample archive with documentation: <https://github.com/Ligengxin96/polymarket-data-samples>

One line added, nothing else touched. The URL carries no affiliate or tracking parameters.

If you would rather see this under **Commercial & Proprietary Services** instead, that is completely fine — say the word and I will move it.