### PR TITLE
Add Algo-Trading-Skills to Trading & Backtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [VerumTrade](https://github.com/muye1202/VerumTrade) - `Python` - A reasoning & decision-trace visible Multi-agent LLM trading-research framework where bull/bear analysts debate each ticker and every decision cites the evidence it rests on.
 - [mt5-httpapi](https://github.com/psyb0t/mt5-httpapi) - `Python` `REST` `MCP` - MetaTrader 5 in a Windows VM (Docker + QEMU/KVM) over REST and MCP: market data, order/position/history management for automated trading and bots, the strategy-tester (backtesting) API, and server-side indicators (RSI/MACD/Bollinger/ADX/VWAP/Ichimoku, order blocks, FVGs). Multi-broker, multi-account.
 - [ibkr-httpapi](https://github.com/psyb0t/ibkr-httpapi) - `Python` `REST` `MCP` - Interactive Brokers over REST and MCP (FastAPI + ib_async over a Linux-native IB Gateway): market data (quotes, historical bars) plus order/position/execution management for automated trading across stocks, options, futures, forex, crypto and CFDs.
+- [Algo-Trading-Skills](https://github.com/HimanshuJ16/Algo-Trading-Skills) - `Python` `AI` `Agent-Skills` - Library of 501 agentskills.io-format skills giving AI coding agents trading-infrastructure playbooks for order idempotency, look-ahead-bias elimination, kill switches, execution algorithms and point-in-time data, each with a standalone Python reference implementation and its own unittest suite.
 
 ## Portfolio Optimization & Risk Analysis
 


### PR DESCRIPTION
## Project

[Algo-Trading-Skills](https://github.com/HimanshuJ16/Algo-Trading-Skills) — Apache-2.0 library of 501 algorithmic-trading skills in the [agentskills.io](https://agentskills.io) format, each pairing a written playbook with a standalone Python reference implementation and its own unittest suite (20,291 tests in CI).

One project, one entry, one line.

## Section placement

`Trading & Backtesting`. The substance is trading-infrastructure engineering backed by runnable Python — order idempotency, look-ahead-bias elimination, kill switches and drawdown circuit breakers, TWAP/VWAP execution, point-in-time data joins. Recent entries in this section cover LLM- and agent-oriented trading tooling (`TraderHarness`, `VerumTrade`), which is the same neighbourhood.

## Format

Single sentence ending in a period, three separate backtick tags, `https://` GitHub URL as the main link (the repository holds the substantive implementation, so no separate site link is needed).

## Checks performed

- **Duplicates** — searched the README for `algo-trading-skills`, `agentskills`, `agent skills` and `HimanshuJ16`: no matches. Searched open and closed PRs on this repo for the same terms: none.
- **Activity** — repository created 2026-07-24, 567 commits, last push 2026-09-04. Inside the 12-month window.
- **Documentation** — README documents installation, the skill-discovery workflow and per-skill anatomy; `CONTRIBUTING.md` and `docs/` cover the structural contract.
- **`Validate PR` locally** — `python scripts/validate_readme.py --diff-from upstream/main` → `Validated 1 entries in added README lines relative to upstream/main. Validation passed.`
- **Site generation locally** — `python site/generate.py` → generates cleanly.

Not a commercial submission; Apache-2.0, source in the repository, no free-tier or pricing considerations apply.