### PR TITLE
Add BlackForge to Commercial & Proprietary Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,6 +699,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 
 ## Commercial & Proprietary Services
 - [AxionQuant](https://axionquant.com) - Unified financial data API covering market prices, fundamentals, disclosures, macroeconomic, and alternative data for long-horizon research and quantitative modeling. Free tier: 1,000 monthly API calls. [PyPI](https://pypi.org/project/axionquant-sdk/)
+- [BlackForge](https://blackforge.so) - Crypto spot market data across nine venues as one row per pair per closed five-minute window: order book depth bands, resting-liquidity lifetimes, taker buy/sell flow, and trade timing. 107 metrics, 120 columns. REST, MCP, CLI, and pay-per-call access. Free tier available.
 - [Prop Firm Risk Calculator](https://prop-firm-risk-calculator.vercel.app) - Free web app for position sizing, stop-loss and max-drawdown on funded accounts, with real tick/pip values for futures, forex, crypto and gold.
 - [RektCalc](https://rektcalc.com) - Free web app for crypto liquidation price, position sizing, PnL and funding-rate calculations across major exchanges, with documented formulas on the site's Learn hub.
 - [AlphaForge](https://alforgelabs.com) - `Python` - Local-first agent-native quant CLI with Optuna TPE optimization, walk-forward testing, anti-overfitting guards, and TradingView Pine v6 code generation. Free trial available. [GitHub](https://github.com/alforge-labs/alpha-forge-mcp)


### PR DESCRIPTION
Adds **BlackForge** to `Commercial & Proprietary Services`, inserted alphabetically.

Checked against the commercial criteria in CONTRIBUTING.md:

- **Permanent free tier, no payment information required.** Three venues, 39 columns, 1M rows/month, daily buckets, 14-day window.
- **Public pricing and free-tier limits:** https://blackforge.so/pricing
- **Public documentation and methodology:** https://blackforge.so/metrics documents all 107 metrics; the `/v1/catalog` endpoint returns a measurement definition, unit and family for every column and needs no API key.
- **Stable HTTPS URL, no affiliate or tracking parameters.**
- Description is factual and non-promotional, ends with a period, placed in the commercial section.

What it is: one wide row per (exchange, symbol) per closed five-minute window across nine spot venues, covering order book depth bands, resting-liquidity lifetimes, liquidity added and removed, taker buy/sell flow and trade timing. Every column is a measurement with a stated definition and a per-row quality mask, not a recommendation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)