### PR TITLE
Add QuantVibe to Trading & Backtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [wickworks](https://github.com/psyb0t/docker-wickworks) - `REST` `MCP` - Stateless OHLC analyzer: POST bars and requested indicators, get back RSI/MACD/Bollinger/ADX/ATR/VWAP/Ichimoku plus smart-money-concept primitives (order blocks, FVGs, BOS/CHoCH, swing structure). No database, no AI signals.
 
 ## Trading & Backtesting
+- [QuantVibe](https://github.com/Ax3lsk3r3/QuantVibe) - `Python` `TypeScript` - Quantitative trading platform and air-gapped bridge connecting Microsoft Qlib (Alpha158 + LightGBM) to MetaTrader 5 execution and FastMCP agents with cryptographic SHA-256 risk gates.
 - [exitkit](https://github.com/charlieyanhx/exitkit) - `Python` - Catalogue of twenty-seven position-exit policies (stop-loss, take-profit, time, volatility, signal-reversal and convergence) behind one interface, with a drop-in adapter for backtesting.py.
 - [lesson-book](https://github.com/holdout-labs/lesson-book) - `Python` - Local-first deterministic tuition memory for traders: pattern-matched reminders, no LLM, overridable rule tables.
 - [cl-lp-rotation-scanner](https://github.com/donnywin85/cl-lp-rotation-scanner) - `Python` - Estimates fees and impermanent loss for concentrated-liquidity pools whose volatile assets can be hedged, then backtests whether rotating capital among pools outperforms remaining in one pool. It does not execute trades or manage liquidity.


### PR DESCRIPTION
## Summary
Adds [QuantVibe](https://github.com/Ax3lsk3r3/QuantVibe) to the \Trading & Backtesting\ section.

## Details
- **Project**: QuantVibe
- **Repository**: https://github.com/Ax3lsk3r3/QuantVibe
- **Category**: Trading & Backtesting
- **Languages**: \Python\ \TypeScript\
- **Description**: Quantitative trading platform and air-gapped bridge connecting Microsoft Qlib (Alpha158 + LightGBM) to MetaTrader 5 execution and FastMCP agents with cryptographic SHA-256 risk gates.
- **License**: MIT
- **Release**: v1.0.0

## Validation
- Verified with \python scripts/validate_readme.py --diff-from main\ (1 entry validated, 0 errors).