### PR TITLE
growth(directory): add AlphaPilot trading tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,6 +711,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [TradeMux Snippets](https://github.com/KVignesh122/trademux-examples) - `Python` - Code snippets for Metatrader (MT5) forex/CFD trading and data retrieval via trademux API client.
 
 ## Commercial & Proprietary Services
+- [AlphaPilot Tools](https://www.alphapilot.tech/tools) - Free browser calculators for perpetual-futures position sizing, liquidation, and funding arbitrage, with documented assumptions and no account required.
 - [AxionQuant](https://axionquant.com) - Unified financial data API covering market prices, fundamentals, disclosures, macroeconomic, and alternative data for long-horizon research and quantitative modeling. Free tier: 1,000 monthly API calls. [PyPI](https://pypi.org/project/axionquant-sdk/)
 - [Prop Firm Risk Calculator](https://prop-firm-risk-calculator.vercel.app) - Free web app for position sizing, stop-loss and max-drawdown on funded accounts, with real tick/pip values for futures, forex, crypto and gold.
 - [RektCalc](https://rektcalc.com) - Free web app for crypto liquidation price, position sizing, PnL and funding-rate calculations across major exchanges, with documented formulas on the site's Learn hub.


### PR DESCRIPTION
Adds AlphaPilot's public trading calculators to **Commercial & Proprietary Services**.

The entry links directly to https://www.alphapilot.tech/tools. These browser tools cover perpetual-futures position sizing, liquidation and funding arbitrage. They can be used without an account or payment details; the linked pages provide assumptions, formulas, examples and methodology sources. The submission concerns the public tools, not a free entitlement to AlphaPilot's separate AI strategy service, and does not claim public source availability.

Verification on 2026-09-09:
- The public funding-arbitrage calculator returned $336 gross funding, $14.60 round-trip fees, $4 slippage, $317.40 estimated net PnL and 9.3 hours to break even for its documented default scenario, while logged out.
- The funding scanner displayed current Hyperliquid, Lighter and Ondo Perps data while logged out.
- No AlphaPilot match in the default-branch README or open/closed PR search.
- The upstream entry validator passed for the added line against the full README, and the upstream static-site generator produced the AlphaPilot Tools link locally.

Affiliation disclosure: prepared by Codex, an AI assistant, on behalf of AlphaPilot and with its owner's authorization. The repository's required PR workflows and maintainer review still determine acceptance.

