### PR TITLE
Add SHORTLIST strategy research and paper trading workbench

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [wickworks](https://github.com/psyb0t/docker-wickworks) - `REST` `MCP` - Stateless OHLC analyzer: POST bars and requested indicators, get back RSI/MACD/Bollinger/ADX/ATR/VWAP/Ichimoku plus smart-money-concept primitives (order blocks, FVGs, BOS/CHoCH, swing structure). No database, no AI signals.
 
 ## Trading & Backtesting
+- [SHORTLIST](https://github.com/zc6503204-collab/stock-strategy-dashboard) - `Python` - Local-first macOS workbench for A-share and US stock strategy screening, paper trading, position sizing, and risk alerts with read-only broker integrations.
 - [exitkit](https://github.com/charlieyanhx/exitkit) - `Python` - Catalogue of twenty-seven position-exit policies (stop-loss, take-profit, time, volatility, signal-reversal and convergence) behind one interface, with a drop-in adapter for backtesting.py.
 - [lesson-book](https://github.com/holdout-labs/lesson-book) - `Python` - Local-first deterministic tuition memory for traders: pattern-matched reminders, no LLM, overridable rule tables.
 - [cl-lp-rotation-scanner](https://github.com/donnywin85/cl-lp-rotation-scanner) - `Python` - Estimates fees and impermanent loss for concentrated-liquidity pools whose volatile assets can be hedged, then backtests whether rotating capital among pools outperforms remaining in one pool. It does not execute trades or manage liquidity.


### PR DESCRIPTION
Adds SHORTLIST to Trading & Backtesting. I maintain the project.

SHORTLIST is an MIT-licensed Python workbench for macOS covering A-share and US stock screening, completed-bar signal confirmation, paper trading, position sizing, and risk alerts. Broker integrations are read-only; it does not submit real orders. Live use requires the user's own market-data permissions. Strategies are experimental, with no validated profitability claim.

The public repository includes implementation, tests, installation instructions, screenshots, and strategy documentation. Checked the current README and searched existing pull requests for SHORTLIST and the repository URL; no duplicate submission was found. The entry uses HTTPS, a language tag, a concise description, and the relevant category.
