### PR TITLE
Add FXpeek to Market Data & Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [PineForge](https://github.com/pineforge-4pass/pineforge-engine) - `C++` - Deterministic offline PineScript v6 → C++ backtest runtime, validated trade-for-trade against TradingView (245/246 strict, 0 engine bugs). Runs locally via Docker and is drivable by AI agents through a bundled MCP server.
 
 ## Market Data & Data Sources
+- [FXpeek](https://fxpeek.com/en/api) - `REST` `MCP` - Source-linked historical reference exchange rates with a per-row source link, CSV/JSON export, an OpenAPI spec and an MCP server. Free, no key required.
 - [Market Brief](https://github.com/beepboop2025/market-brief) - `Python` `JavaScript` - Source-linked money-market, capital-market, and liquidity briefs with local snapshot comparisons and explicit missing-data states.
 - [Cambio Uruguay](https://cambio-uruguay.com) - `TypeScript` `REST` `MCP` - Collectors and public API for Uruguayan retail buy/sell exchange rates and historical series by source and quote type. [GitHub](https://github.com/eduair94/cambio-uruguay)
 - [ashare-data-immunity](https://github.com/holdout-labs/ashare-data-immunity) - `Python` - A-share daily-bar data immunity: cleaning, board-aware price limits (ST date-aware), suspensions, audits, SHA-256 snapshots and evidence-tracked repair.


### PR DESCRIPTION
FXpeek: source-linked historical reference exchange rates (REST + MCP), free with no key. Each row carries a source link; CSV/JSON export and OpenAPI at https://fxpeek.com/openapi.json.