### PR TITLE
Point Jupyter Quant to its maintained repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [Nova-TradingAgent](https://github.com/rufeng0411/Nova-TradingAgent) - `Python` `A-shares` - Self-hosted 15-agent research desk (debate graph, optional Tushare L2 and Qlib). Does not place trades.
 - [QFO Quant Platform](https://www.qfo-quant-platform.com/) - `Python` `React` `A-shares` - Local-first quantitative research and backtesting platform with data synchronization, multi-asset screening, factor analysis, portfolio optimization, risk analysis, and optional LLM-assisted news analysis. [GitHub](https://github.com/yeh2017/QFO-Quant-Platform)
 - [dsh-quant](https://github.com/pengpengyi92/dsh-quant) - `TypeScript` `DeepSeek Harness` - Agent-native quantitative research toolkit for DeepSeek Harness: 46 tools across data, alpha, ML, risk, execution and ecosystem domains, with an end-to-end research pipeline.
-- [Jupyter Quant](https://github.com/gnzsnz/jupyter-quant) - `Python` - A dockerized Jupyter quant research environment with preloaded tools for quant analysis, statsmodels, pymc, arch, py_vollib, zipline-reloaded, PyPortfolioOpt, etc.
+- [Jupyter Quant](https://github.com/quantbelt/jupyter-quant) - `Python` - A dockerized Jupyter quant research environment with preloaded tools for quant analysis, statsmodels, pymc, arch, py_vollib, zipline-reloaded, PyPortfolioOpt, etc.
 
 ## Cross-Language Frameworks
 


### PR DESCRIPTION
Jupyter Quant still points to `gnzsnz/jupyter-quant`, whose [README explicitly announces its move](https://github.com/gnzsnz/jupyter-quant/blob/master/README.md) to `quantbelt/jupyter-quant`. Update the primary URL to that maintained repository, preserving the entry's description, tags, and category.

Verified the destination README and substantive Dockerfile/entrypoint implementation. GitHub metadata reports the destination non-archived and last pushed September 11, 2026. This addresses WIL-191 finding F141 based on the author's migration notice.

Validation: changed-entry check passes (1 entry); full README validation passes (713 entries, 81 existing warnings); all 147 tests pass; diff check passes. A README-based site preview generated 713 projects with the updated target. Independent review found no issues.

Tracking: [WIL-191](https://linear.app/wilsonfreitas/issue/WIL-191/weekly-readme-audit-report). This is one audit finding; the broader issue remains In Progress.