### PR TITLE
Allow historical-project parser test to follow README changes

### DIFF
--- a/tests/test_historical_projects.py
+++ b/tests/test_historical_projects.py
@@ -65,9 +65,14 @@ class HistoricalProjectContractTests(unittest.TestCase):
             if entry["category"] == "Historical & Archived Projects"
         ]
 
+        expected_projects = {
+            entry.name
+            for entry in iter_readme_entries(ROOT / "README.md")
+            if entry.section == HISTORICAL_SECTION
+        }
+        self.assertTrue(expected_projects)
         self.assertEqual(
-            {entry["project"] for entry in historical},
-            {"fooltrader", "pipeline-live", "pybacktest"},
+            {entry["project"] for entry in historical}, expected_projects
         )
         self.assertTrue(all("Historical" in entry["languages"] for entry in historical))
 


### PR DESCRIPTION
The historical-project contract test hardcodes the original three project names. Adding valid Historical entries therefore fails the full test suite even when both README parsers correctly include them.

Derive the expected Historical names from `iter_readme_entries` and compare them with the independent site parser. Keep the nonempty-set, Historical-tag, section-order, and existing removal assertions. This allows curation changes while still detecting dropped/misclassified entries.

Validation: reproduced the old assertion failure with WIL-191's 11 historical moves; all 147 tests pass with this fix and the current README, and all 147 pass with the complete archive-cleanup README (697 projects, 14 Historical entries). Independent review found no issues.

Integration note: the existing `PR Review` workflow only accepts README-only changes, so it will reject this test-only maintenance PR. Its trusted-base execution and permissions remain unchanged. This is a prerequisite for the separate WIL-191 archive cleanup, not completion of the whole audit.

Tracking: [WIL-191](https://linear.app/wilsonfreitas/issue/WIL-191/weekly-readme-audit-report).