### PR TITLE
Canonicalize the nested QuantLib C++ reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,7 +614,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [QuantLibAAD](https://github.com/auto-differentiation/QuantLibAAD) - Fast risks with QuantLib in C++.
 - [XAD](https://github.com/auto-differentiation/xad) - Automatic Differentation (AAD) Library.
 - [QuantLib](https://github.com/lballabio/QuantLib) - The QuantLib project is aimed at providing a comprehensive software framework for quantitative finance.
-  - QuantLibRisks - Fast risks with QuantLib in [Python](https://pypi.org/project/QuantLib-Risks/) and [C++](https://github.com/auto-differentiation/QuantLib-Risks-Cpp)
+  - QuantLibRisks - Fast risks with QuantLib in [Python](https://pypi.org/project/QuantLib-Risks/) and [C++](https://github.com/auto-differentiation/QuantLibAAD)
   - XAD - Automatic Differentiation (AAD) Library in [Python](https://pypi.org/project/xad/) and [C++](https://github.com/auto-differentiation/xad/)
   - [JQuantLib](https://github.com/frgomes/jquantlib) - Java port.
   - [RQuantLib](https://github.com/eddelbuettel/rquantlib) - R port.


### PR DESCRIPTION
Replace the remaining nested QuantLib-Risks-Cpp link with its verified canonical QuantLibAAD repository URL. Surrounding text, category, parent and placement are unchanged; both URLs resolve to the same GitHub repository.

Draft pending the narrow nested-reference validation prerequisite. Current main rejects this existing non-entry bullet as malformed; the fix preserves entry parsing and requires unchanged reference structure plus authenticated immutable-repository-ID equality.

The prerequisite validator accepts this actual diff. Automated review will be run with the prerequisite before merge. This is F024/F073's last unresolved occurrence; the main QuantLibAAD entry was fixed in #662.

Evidence/plan: https://linear.app/wilsonfreitas/document/wil-191-batch-g-canonicalization-evidence-and-review-prerequisite-7b25aab6615d
Tracks WIL-191.