### PR TITLE
Use canonical lowercase MetaTrader5 PyPI URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ A curated list of insanely awesome libraries, packages and resources for Quants 
 - [BloombergFetch](https://github.com/ArturSepp/BloombergFetch) - `Python` - Bloomberg Desktop API data (prices, implied volatilities, fundamentals) as pandas DataFrames via blpapi.
 - [tiingo](https://github.com/hydrosquall/tiingo-python) - `Python` - Python interface for daily composite prices/OHLC/Volume + Real-time News Feeds, powered by the Tiingo Data Platform.
 - [finlight](https://finlight.me) - `Python` `TypeScript` - Real-time financial and geopolitical news API with sentiment analysis and entity tagging over REST and WebSocket. [GitHub](https://github.com/jubeiargh/finlight-client-py)
-- [metatrader5](https://pypi.org/project/MetaTrader5/) - `Python` - API Connector to MetaTrader 5 Terminal. (Last updated: 2026-02-20).
+- [metatrader5](https://pypi.org/project/metatrader5/) - `Python` - API Connector to MetaTrader 5 Terminal. (Last updated: 2026-02-20).
 - [akshare](https://github.com/akfamily/akshare) - `Python` - AkShare is an elegant and simple financial data interface library for Python, built for human beings! <https://akshare.readthedocs.io>.
 - [yahooquery](https://github.com/dpguthrie/yahooquery) - `Python` - Python interface for retrieving data through unofficial Yahoo Finance API.
 - [investpy](https://github.com/alvarobartt/investpy) - `Python` - Financial Data Extraction from Investing.com with Python! <https://investpy.readthedocs.io/>.


### PR DESCRIPTION
The post-cleanup WIL-191 audit preview found a permanent redirect from the capitalized MetaTrader5 PyPI URL to its lowercase canonical form. Update that one URL; both official PyPI JSON endpoints identify the same package. The tracked date and entry description are unchanged.

Validation: changed-entry validation passes; independent review found no issues. Official evidence: https://pypi.org/pypi/MetaTrader5/json and https://pypi.org/pypi/metatrader5/json.

Tracks WIL-191. This corrects one preview finding; StockVektor access, EDGAR's September14 recheck, and final audit reconciliation remain open.